### PR TITLE
US-12: estadisticas de administrador

### DIFF
--- a/src/main/java/app/controllers/AdministradorController.java
+++ b/src/main/java/app/controllers/AdministradorController.java
@@ -1,6 +1,8 @@
 package app.controllers;
 
-import app.dto.TemporalDto;
+import app.dto.EstadisticasDto;
+import app.servicios.EstadisticasService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,11 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/administrador")
+@RequiredArgsConstructor
 public class AdministradorController {
 
+    private final EstadisticasService estadisticasService;
+
     @GetMapping("/estadisticas")
-    public ResponseEntity<TemporalDto> getEstadisticas() {
-        return ResponseEntity.ok(new TemporalDto("GET /administrador/estadisticas"));
+    public ResponseEntity<EstadisticasDto> getEstadisticas() {
+        return ResponseEntity.ok(estadisticasService.getEstadisticas());
     }
 
 }

--- a/src/main/java/app/dto/EstadisticasDto.java
+++ b/src/main/java/app/dto/EstadisticasDto.java
@@ -1,0 +1,13 @@
+package app.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class EstadisticasDto {
+    private int totalUsuarios;
+    private int totalFiguritasPublicadas;
+    private int totalPropuestas;
+    private int totalSubastasActivas;
+}

--- a/src/main/java/app/dto/OperacionesDto.java
+++ b/src/main/java/app/dto/OperacionesDto.java
@@ -3,7 +3,6 @@ package app.dto;
 import app.model.entities.FiguritaIntercambiable;
 import app.model.entities.Propuesta;
 import app.model.entities.Subasta;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,15 +13,11 @@ import lombok.Setter;
 @AllArgsConstructor
 public class OperacionesDto {
 
-    @JsonProperty("figuritas_publicadas")
     List<FiguritaIntercambiable> figuritasPublicadas;
 
-    @JsonProperty("propuestas_enviadas")
     List<Propuesta> propuestasEnviadas;
 
-    @JsonProperty("propuestas_recibidas")
     List<Propuesta> propuestasRecibidas;
 
-    @JsonProperty("subastas_activas")
     List<Subasta> subastasActivas;
 }

--- a/src/main/java/app/repositories/RepositorioPropuestas.java
+++ b/src/main/java/app/repositories/RepositorioPropuestas.java
@@ -10,5 +10,7 @@ public interface RepositorioPropuestas {
     // Propuestas recibidas
     List<Propuesta> findByDestinoId(String userId);
 
+    List<Propuesta> findAll();
+
     void save(Propuesta propuesta);
 }

--- a/src/main/java/app/repositories/RepositorioPropuestas.java
+++ b/src/main/java/app/repositories/RepositorioPropuestas.java
@@ -12,5 +12,7 @@ public interface RepositorioPropuestas {
 
     List<Propuesta> findAll();
 
+    int count();
+
     void save(Propuesta propuesta);
 }

--- a/src/main/java/app/repositories/RepositorioSubastas.java
+++ b/src/main/java/app/repositories/RepositorioSubastas.java
@@ -6,5 +6,7 @@ import java.util.List;
 public interface RepositorioSubastas {
     List<Subasta> findByUsuarioId(String userId);
 
+    List<Subasta> findAll();
+
     void save(Subasta subasta);
 }

--- a/src/main/java/app/repositories/RepositorioSubastas.java
+++ b/src/main/java/app/repositories/RepositorioSubastas.java
@@ -8,6 +8,8 @@ public interface RepositorioSubastas {
 
     List<Subasta> findAll();
 
+    Subasta findById(String id);
+
     int count();
 
     void save(Subasta subasta);

--- a/src/main/java/app/repositories/RepositorioSubastas.java
+++ b/src/main/java/app/repositories/RepositorioSubastas.java
@@ -8,5 +8,7 @@ public interface RepositorioSubastas {
 
     List<Subasta> findAll();
 
+    int count();
+
     void save(Subasta subasta);
 }

--- a/src/main/java/app/repositories/RepositorioUsuarios.java
+++ b/src/main/java/app/repositories/RepositorioUsuarios.java
@@ -9,5 +9,7 @@ public interface RepositorioUsuarios {
 
     List<Usuario> findAll();
 
+    int count();
+
     void save(Usuario usuario);
 }

--- a/src/main/java/app/repositories/RepositorioUsuarios.java
+++ b/src/main/java/app/repositories/RepositorioUsuarios.java
@@ -1,10 +1,13 @@
 package app.repositories;
 
 import app.model.entities.Usuario;
+import java.util.List;
 
 public interface RepositorioUsuarios {
 
     Usuario findById(String id);
+
+    List<Usuario> findAll();
 
     void save(Usuario usuario);
 }

--- a/src/main/java/app/repositories/impl/RepositorioPropuestasEnMemoria.java
+++ b/src/main/java/app/repositories/impl/RepositorioPropuestasEnMemoria.java
@@ -2,6 +2,7 @@ package app.repositories.impl;
 
 import app.model.entities.Propuesta;
 import app.repositories.RepositorioPropuestas;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,11 @@ public class RepositorioPropuestasEnMemoria implements RepositorioPropuestas {
         return storage.values().stream()
                 .filter(p -> p.getUsuarioDestino().getId().equals(userId))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Propuesta> findAll() {
+        return new ArrayList<>(storage.values());
     }
 
     @Override

--- a/src/main/java/app/repositories/impl/RepositorioPropuestasEnMemoria.java
+++ b/src/main/java/app/repositories/impl/RepositorioPropuestasEnMemoria.java
@@ -34,6 +34,11 @@ public class RepositorioPropuestasEnMemoria implements RepositorioPropuestas {
     }
 
     @Override
+    public int count() {
+        return storage.size();
+    }
+
+    @Override
     public void save(Propuesta propuesta) {
         storage.put(propuesta.getId(), propuesta);
     }

--- a/src/main/java/app/repositories/impl/RepositorioSubastasEnMemoria.java
+++ b/src/main/java/app/repositories/impl/RepositorioSubastasEnMemoria.java
@@ -27,6 +27,11 @@ public class RepositorioSubastasEnMemoria implements RepositorioSubastas {
     }
 
     @Override
+    public int count() {
+        return storage.size();
+    }
+
+    @Override
     public void save(Subasta subasta) {
         storage.put(subasta.getId(), subasta);
     }

--- a/src/main/java/app/repositories/impl/RepositorioSubastasEnMemoria.java
+++ b/src/main/java/app/repositories/impl/RepositorioSubastasEnMemoria.java
@@ -2,6 +2,7 @@ package app.repositories.impl;
 
 import app.model.entities.Subasta;
 import app.repositories.RepositorioSubastas;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,11 @@ public class RepositorioSubastasEnMemoria implements RepositorioSubastas {
         return storage.values().stream()
                 .filter(s -> s.getUsuario().getId().equals(userId))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Subasta> findAll() {
+        return new ArrayList<>(storage.values());
     }
 
     @Override

--- a/src/main/java/app/repositories/impl/RepositorioUsuariosEnMemoria.java
+++ b/src/main/java/app/repositories/impl/RepositorioUsuariosEnMemoria.java
@@ -2,7 +2,9 @@ package app.repositories.impl;
 
 import app.model.entities.Usuario;
 import app.repositories.RepositorioUsuarios;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Repository;
 
@@ -14,6 +16,11 @@ public class RepositorioUsuariosEnMemoria implements RepositorioUsuarios {
     @Override
     public Usuario findById(String id) {
         return storage.get(id);
+    }
+
+    @Override
+    public List<Usuario> findAll() {
+        return new ArrayList<>(storage.values());
     }
 
     @Override

--- a/src/main/java/app/repositories/impl/RepositorioUsuariosEnMemoria.java
+++ b/src/main/java/app/repositories/impl/RepositorioUsuariosEnMemoria.java
@@ -24,6 +24,11 @@ public class RepositorioUsuariosEnMemoria implements RepositorioUsuarios {
     }
 
     @Override
+    public int count() {
+        return storage.size();
+    }
+
+    @Override
     public void save(Usuario usuario) {
         storage.put(usuario.getId(), usuario);
     }

--- a/src/main/java/app/servicios/EstadisticasService.java
+++ b/src/main/java/app/servicios/EstadisticasService.java
@@ -1,0 +1,7 @@
+package app.servicios;
+
+import app.dto.EstadisticasDto;
+
+public interface EstadisticasService {
+    EstadisticasDto getEstadisticas();
+}

--- a/src/main/java/app/servicios/impl/EstadisticasServiceImpl.java
+++ b/src/main/java/app/servicios/impl/EstadisticasServiceImpl.java
@@ -1,0 +1,36 @@
+package app.servicios.impl;
+
+import app.dto.EstadisticasDto;
+import app.repositories.RepositorioPropuestas;
+import app.repositories.RepositorioSubastas;
+import app.repositories.RepositorioUsuarios;
+import app.servicios.EstadisticasService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EstadisticasServiceImpl implements EstadisticasService {
+
+    private final RepositorioUsuarios repositorioUsuarios;
+    private final RepositorioPropuestas repositorioPropuestas;
+    private final RepositorioSubastas repositorioSubastas;
+
+    @Override
+    public EstadisticasDto getEstadisticas() {
+        int totalUsuarios = repositorioUsuarios.findAll().size();
+
+        int totalFiguritasPublicadas = repositorioUsuarios.findAll().stream()
+                .mapToInt(u -> u.getColeccion().getRepetidas().size())
+                .sum();
+
+        int totalPropuestas = repositorioPropuestas.findAll().size();
+
+        int totalSubastasActivas = (int) repositorioSubastas.findAll().stream()
+                .filter(s -> s.estaActivo())
+                .count();
+
+        return new EstadisticasDto(totalUsuarios, totalFiguritasPublicadas,
+                totalPropuestas, totalSubastasActivas);
+    }
+}

--- a/src/main/java/app/servicios/impl/EstadisticasServiceImpl.java
+++ b/src/main/java/app/servicios/impl/EstadisticasServiceImpl.java
@@ -1,6 +1,7 @@
 package app.servicios.impl;
 
 import app.dto.EstadisticasDto;
+import app.model.entities.Subasta;
 import app.repositories.RepositorioPropuestas;
 import app.repositories.RepositorioSubastas;
 import app.repositories.RepositorioUsuarios;
@@ -18,16 +19,16 @@ public class EstadisticasServiceImpl implements EstadisticasService {
 
     @Override
     public EstadisticasDto getEstadisticas() {
-        int totalUsuarios = repositorioUsuarios.findAll().size();
+        int totalUsuarios = repositorioUsuarios.count();
 
         int totalFiguritasPublicadas = repositorioUsuarios.findAll().stream()
                 .mapToInt(u -> u.getColeccion().getRepetidas().size())
                 .sum();
 
-        int totalPropuestas = repositorioPropuestas.findAll().size();
+        int totalPropuestas = repositorioPropuestas.count();
 
         int totalSubastasActivas = (int) repositorioSubastas.findAll().stream()
-                .filter(s -> s.estaActivo())
+                .filter(Subasta::estaActivo)
                 .count();
 
         return new EstadisticasDto(totalUsuarios, totalFiguritasPublicadas,

--- a/src/test/java/app/controllers/AdministradorControllerTest.java
+++ b/src/test/java/app/controllers/AdministradorControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -17,8 +18,13 @@ class AdministradorControllerTest {
     MockMvc mockMvc;
 
     @Test
-    void getEstadisticasNoFalla() throws Exception {
-        mockMvc.perform(get("/administrador/estadisticas")).andExpect(status().isOk());
+    void getEstadisticas_retorna200ConDatos() throws Exception {
+        mockMvc.perform(get("/administrador/estadisticas"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_usuarios").isNumber())
+                .andExpect(jsonPath("$.total_figuritas_publicadas").isNumber())
+                .andExpect(jsonPath("$.total_propuestas").isNumber())
+                .andExpect(jsonPath("$.total_subastas_activas").isNumber());
     }
 
 }

--- a/src/test/java/app/servicios/impl/EstadisticasServiceImplTest.java
+++ b/src/test/java/app/servicios/impl/EstadisticasServiceImplTest.java
@@ -1,0 +1,102 @@
+package app.servicios.impl;
+
+import app.dto.EstadisticasDto;
+import app.model.entities.Coleccion;
+import app.model.entities.FiguritaIntercambiable;
+import app.model.entities.Subasta;
+import app.model.entities.Usuario;
+import app.repositories.RepositorioPropuestas;
+import app.repositories.RepositorioSubastas;
+import app.repositories.RepositorioUsuarios;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EstadisticasServiceImplTest {
+
+    @Mock
+    private RepositorioUsuarios repositorioUsuarios;
+    @Mock
+    private RepositorioPropuestas repositorioPropuestas;
+    @Mock
+    private RepositorioSubastas repositorioSubastas;
+
+    private EstadisticasServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EstadisticasServiceImpl(repositorioUsuarios, repositorioPropuestas, repositorioSubastas);
+    }
+
+    @Test
+    void getEstadisticas_sinDatos_retornaTodosCeros() {
+        when(repositorioUsuarios.count()).thenReturn(0);
+        when(repositorioUsuarios.findAll()).thenReturn(List.of());
+        when(repositorioPropuestas.count()).thenReturn(0);
+        when(repositorioSubastas.findAll()).thenReturn(List.of());
+
+        EstadisticasDto resultado = service.getEstadisticas();
+
+        assertEquals(0, resultado.getTotalUsuarios());
+        assertEquals(0, resultado.getTotalFiguritasPublicadas());
+        assertEquals(0, resultado.getTotalPropuestas());
+        assertEquals(0, resultado.getTotalSubastasActivas());
+    }
+
+    @Test
+    void getEstadisticas_conDatos_retornaValoresCorrectos() {
+        Coleccion coleccionConDos = new Coleccion();
+        coleccionConDos.getRepetidas().add(new FiguritaIntercambiable(null, 1, new ArrayList<>()));
+        coleccionConDos.getRepetidas().add(new FiguritaIntercambiable(null, 2, new ArrayList<>()));
+
+        Coleccion coleccionConUna = new Coleccion();
+        coleccionConUna.getRepetidas().add(new FiguritaIntercambiable(null, 3, new ArrayList<>()));
+
+        Usuario u1 = new Usuario("u-1", "Lucas", coleccionConDos, "+54911", new ArrayList<>());
+        Usuario u2 = new Usuario("u-2", "Sofía", coleccionConUna, "+54911", new ArrayList<>());
+
+        Subasta subastaActiva = new Subasta("s-1", u1,
+                LocalDateTime.now().minusHours(1), LocalDateTime.now().plusDays(2), null, null);
+
+        when(repositorioUsuarios.count()).thenReturn(2);
+        when(repositorioUsuarios.findAll()).thenReturn(List.of(u1, u2));
+        when(repositorioPropuestas.count()).thenReturn(4);
+        when(repositorioSubastas.findAll()).thenReturn(List.of(subastaActiva));
+
+        EstadisticasDto resultado = service.getEstadisticas();
+
+        assertEquals(2, resultado.getTotalUsuarios());
+        assertEquals(3, resultado.getTotalFiguritasPublicadas());
+        assertEquals(4, resultado.getTotalPropuestas());
+        assertEquals(1, resultado.getTotalSubastasActivas());
+    }
+
+    @Test
+    void getEstadisticas_filtraSoloSubastasActivas() {
+        Usuario u1 = new Usuario("u-1", "Lucas", new Coleccion(), "+54911", new ArrayList<>());
+
+        Subasta activa   = new Subasta("s-1", u1,
+                LocalDateTime.now().minusHours(1), LocalDateTime.now().plusDays(2), null, null);
+        Subasta vencida  = new Subasta("s-2", u1,
+                LocalDateTime.now().minusDays(3), LocalDateTime.now().minusDays(1), null, null);
+
+        when(repositorioUsuarios.count()).thenReturn(1);
+        when(repositorioUsuarios.findAll()).thenReturn(List.of(u1));
+        when(repositorioPropuestas.count()).thenReturn(0);
+        when(repositorioSubastas.findAll()).thenReturn(List.of(activa, vencida));
+
+        EstadisticasDto resultado = service.getEstadisticas();
+
+        assertEquals(1, resultado.getTotalSubastasActivas());
+    }
+}


### PR DESCRIPTION
## Descripción:                                                                                                                                                                                  
Se implementa el caso de uso de administrador para consultar estadísticas globales de la plataforma. Expone el endpoint `GET /administrador/estadisticas` que devuelve:

- Total de usuarios registrados
- Total de figuritas publicadas para intercambio
- Total de propuestas creadas
- Total de subastas activas

Se agregaron métodos count() en los repositorios de usuarios, propuestas y subastas para evitar traer colecciones completas donde no hace falta. 

Incluye test unitario de EstadisticasServiceImpl y test de integración del controller

## cURL
```
curl --request get \
  --url http://127.0.0.1:8080/administrador/estadisticas
```