### PR TITLE
README completo y Javadoc en métodos no triviales 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,209 @@
-# java-base-project
+# TACS 2026 1C - Grupo 5
 
-Esta es una plantilla de proyecto diseñada para:
+Aplicación de intercambio de figuritas del Mundial. Permite a los usuarios gestionar sus colecciones, proponer intercambios, participar en subastas y calificarse entre sí.
 
-* Java 21. :warning: Si bien el proyecto no lo limita explícitamente, el comando `mvn verify` no funcionará con versiones más antiguas de Java.
-* JUnit 5. :warning: La versión 5 de JUnit es la más nueva del framework y presenta algunas diferencias respecto a la versión "clásica" (JUnit 4). Para mayores detalles, ver:
-  * [Apunte de herramientas](https://docs.google.com/document/d/1VYBey56M0UU6C0689hAClAvF9ILE6E7nKIuOqrRJnWQ/edit#heading=h.dnwhvummp994)
-  * [Entrada de Blog (en inglés)](https://www.baeldung.com/junit-5-migration)
-  * [Entrada de Blog (en español)](https://www.paradigmadigital.com/dev/nos-espera-junit-5/)
-* Maven 3.9 o superior (recomendado)
+## Stack tecnológico
+
+| Componente       | Tecnología                 |
+|------------------|----------------------------|
+| Lenguaje         | Java 17                    |
+| Framework        | Spring Boot 3.2.5          |
+| Build            | Maven 3.9+                 |
+| Tests            | JUnit 5 + Mockito          |
+| Cobertura        | JaCoCo                     |
+| Calidad          | SpotBugs                   |
+| Boilerplate      | Lombok                     |
+| Containerización | Docker (multi-stage build) |
+| CI               | GitHub Actions             |
+
+## Levantar la aplicación
+
+### Con Docker (recomendado)
+
+```bash
+docker build -t tacs-grupo5 .
+docker run -p 8080:8080 tacs-grupo5
+```
+
+### Con Maven
+
+```bash
+mvn spring-boot:run
+```
+
+La aplicación queda disponible en `http://localhost:8080`.
+
+## Endpoints disponibles
+
+### Perfil
+
+| Método | Endpoint                             | Descripción                                                                                |
+|--------|--------------------------------------|--------------------------------------------------------------------------------------------|
+| GET    | `/perfil/{user_id}/operaciones`      | Retorna figuritas publicadas, propuestas enviadas/recibidas y subastas activas del usuario |
+| GET    | `/perfil/{user_id}/intercambiables`  | Lista las figuritas intercambiables del usuario                                            |
+| GET    | `/perfil/{user_id}/sugerencias`      | Sugiere perfiles que tienen figuritas que le faltan al usuario                             |
+| GET    | `/perfil/{user_id}/notificaciones`   | Lista las notificaciones del usuario                                                       |
+| POST   | `/perfil/{perfil_id}/calificaciones` | Agrega una calificación (1–5) a un perfil                                                  |
+
+**Header requerido en calificaciones:** `autor_id`
+
+**Body de calificación:**
+
+```json
+{
+  "valor": 4,
+  "descripcion": "Buen intercambio"
+}
+```
+
+### Propuestas
+
+| Método | Endpoint                         | Descripción                       |
+|--------|----------------------------------|-----------------------------------|
+| POST   | `/propuestas`                    | Crea una propuesta de intercambio |
+| PATCH  | `/propuestas/{prop_id}/aceptar`  | Acepta una propuesta pendiente    |
+| PATCH  | `/propuestas/{prop_id}/rechazar` | Rechaza una propuesta pendiente   |
+
+**Body de creación:**
+
+```json
+{
+  "autor_id": "1000",
+  "destinatario_id": "1001",
+  "figurita_buscada_id": "ARG-10",
+  "figuritas_ofrecidas_ids": [
+    "FRA-10",
+    "BRA-11"
+  ]
+}
+```
+
+### Subastas
+
+| Método | Endpoint                        | Descripción                        |
+|--------|---------------------------------|------------------------------------|
+| POST   | `/subastas`                     | Crea una subasta para una figurita |
+| POST   | `/subastas/{sub_id}/propuestas` | Oferta en una subasta existente    |
+
+**Header requerido:** `user_id`
+
+**Body de creación:**
+
+```json
+{
+  "figurita_id": "ARG-10",
+  "duracion": 60
+}
+```
+
+**Body de oferta:**
+
+```json
+{
+  "usuario_id": "1001",
+  "figuritas_ofrecidas_id": [
+    "FRA-10"
+  ]
+}
+```
+
+### Colecciones
+
+| Método | Endpoint                          | Descripción                                              |
+|--------|-----------------------------------|----------------------------------------------------------|
+| POST   | `/colecciones/{col_id}/faltantes` | Agrega una figurita a la lista de faltantes              |
+| POST   | `/colecciones/{col_id}/repetidas` | Agrega una figurita repetida disponible para intercambio |
+
+**Header requerido en repetidas:** `user_id`
+
+**Body de faltante:**
+
+```json
+{
+  "fig_id": "ARG-10"
+}
+```
+
+**Body de repetida:**
+
+```json
+{
+  "fig_id": "ARG-10",
+  "cantidad_disponible": 2,
+  "modos_intercambio": [
+    "INTERCAMBIO",
+    "SUBASTA"
+  ]
+}
+```
+
+### Figuritas
+
+| Método | Endpoint     | Descripción                                            |
+|--------|--------------|--------------------------------------------------------|
+| GET    | `/figuritas` | Lista figuritas intercambiables con filtros opcionales |
+
+**Query params opcionales:** `numero`, `seleccion`, `jugador`
+
+### Administrador
+
+| Método | Endpoint                      | Descripción                                                           |
+|--------|-------------------------------|-----------------------------------------------------------------------|
+| GET    | `/administrador/estadisticas` | Retorna estadísticas globales (usuarios, figuritas, subastas activas) |
+
+---
+
+## Colección de Postman
+
+El archivo `postman_collection.json` en la raíz del repositorio contiene todos los endpoints preconfigurados con ejemplos de request. Para usarla:
+
+1. Abrir Postman
+2. **Import** > seleccionar `postman_collection.json`
+3. Levantar la aplicación y ejecutar los requests
+
+Los IDs de perfiles, figuritas y colecciones usados en los ejemplos corresponden a los datos de prueba precargados al iniciar la app.
+
+---
+
+## Decisiones de diseño
+
+### `MetodoIntercambio` como enum y no como entidad
+
+Los métodos de intercambio son un conjunto cerrado y conocido en tiempo de compilación (`INTERCAMBIO`, `SUBASTA`). Modelarlos como enum evita una tabla extra en la base de datos, elimina joins innecesarios y permite usar el compilador como validación. Si en el futuro aparece un nuevo método de
+intercambio, el cambio es deliberado y controlado.
+
+### La colección tiene su propio repositorio separado del perfil
+
+`Coleccion` es un agregado con identidad propia y lógica no trivial (deduplicación de faltantes, acumulación de repetidas). Separar su repositorio del de `Perfil` respeta el principio de responsabilidad única y facilita la futura migración a base de datos, donde serán tablas distintas. Además,
+permite que operaciones sobre la colección no requieran cargar el perfil completo.
+
+---
 
 ## Ejecutar tests
 
-```
+```bash
 mvn test
 ```
 
-## Validar el proyecto de forma exhaustiva
+## Validar el proyecto
 
-```
+```bash
 mvn clean verify
 ```
 
-Este comando hará lo siguiente:
-
-1. Ejecutará los tests
-2. Validará las convenciones de formato mediante checkstyle
-3. Detectará la presencia de (ciertos) code smells
-4. Validará la cobertura del proyecto
-
-## Entrega del proyecto
-
-Para entregar el proyecto, crear un tag llamado `entrega-final`. Es importante que antes de realizarlo se corra la validación
-explicada en el punto anterior. Se recomienda hacerlo de la siguiente forma:
-
-```
-mvn clean verify && git tag entrega-final && git push origin HEAD --tags
-```
+Este comando ejecuta los tests, corre el análisis de SpotBugs y valida la cobertura mínima con JaCoCo.
 
 ## Configuración del IDE (IntelliJ)
 
-### Usar el SDK de Java 21
+### SDK de Java 17
 
-1. En **File/Project Structure...**, ir a **Project Settings | Project**
-2. En **Project SDK** seleccionar la versión 21 y en **Project language level** seleccionar el nivel 21 (coincidente con el SDK)
+En **File > Project Structure > Project**, seleccionar SDK 17 y language level 17.
 
-![image](https://user-images.githubusercontent.com/39303639/228126065-221b9851-fb96-4f7f-a8e1-010732dc7ef6.png)
+### Fin de línea Unix
 
-### Usar fin de línea unix
+En **File > Settings > Editor > Code Style**, seleccionar `Unix and OS X (\n)` en **Line separator**.
 
-1. En **File/Settings...**, ir a **Editor | Code Style**.
-2. En la lista **Line separator**, seleccionar `Unix and OS X (\n)`.
+### Indentación con 2 espacios
 
-![image](https://user-images.githubusercontent.com/39303639/228126546-352289fa-8feb-4b39-99db-d8b860915fea.png)
+En **File > Settings > Editor > Code Style > Java > Tabs and Indents**, setear Tab size, Indent y Continuation indent en 2, 2 y 4.
 
-### Tabular con dos espacios
-
-1. En **File/Settings...**, ir a **Editor | Code Style | Java | Tabs and Indents**.
-2. Cambiar **Tab size**, **Indent** y **Continuation indent** a 2, 2 y 4 respectivamente:
-
-![image](https://user-images.githubusercontent.com/39303639/228127009-8c84ea72-969b-4e05-b311-45e3688a4164.png)
-
-### Ordenar los imports
-
-1. En **File/Settings...**, ir a **Editor | Code Style | Java | Imports**.
-2. Cambiar **Class count to use import with '\*'** y **Names count to use static import with '\*'** a un número muy alto (ej: 99).
-3. En **Import Layout**, dejarlo como se muestra a continuación:
-   - `import static all other imports`
-   - `<blank line>`
-   - `import all other imports`
-
-![image](https://user-images.githubusercontent.com/39303639/228126787-36f9ecff-27f2-4b99-bf11-a6bd89f67087.png)
-
-### Instalar y configurar Checkstyle
-
-1. Instalar el plugin https://plugins.jetbrains.com/plugin/1065-checkstyle-idea
-2. En **File/Settings...**, ir a **Tools | Checkstyle**.
-3. Configurarlo activando los Checks de Google y una versión de Checkstyle compatible con el plugin (alinear con la usada por `maven-checkstyle-plugin` del proyecto).
-
-![image](https://github.com/dds-utn/java-base-project/assets/11719816/b1edc122-4675-4f8d-bffc-9e3d3366fac6)

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.60</minimum>
+                      <minimum>0.80</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -86,14 +86,15 @@
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-<!--                      < TODO: Volver a subir el coverage-->
-                      <minimum>0</minimum>
+                      <minimum>0.60</minimum>
                     </limit>
                   </limits>
                 </rule>
               </rules>
               <excludes>
                 <exclude>Main.class</exclude>
+                <!-- DTOs y requests son POJOs sin lógica de negocio: solo campos y getters/setters -->
+                <exclude>app/dto/**</exclude>
               </excludes>
             </configuration>
           </execution>

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1,0 +1,726 @@
+{
+  "info": {
+    "name": "TACS - Figuritas Mundial",
+    "description": "Collection para testear todos los endpoints del TP de TACS - Intercambio de figuritas del Mundial",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8080"
+    }
+  ],
+  "item": [
+    {
+      "name": "Ping",
+      "item": [
+        {
+          "name": "GET /ping",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/ping",
+              "host": ["{{base_url}}"],
+              "path": ["ping"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Body es pong', () => pm.expect(pm.response.text()).to.eql('pong'));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US1 - Publicar figurita para intercambio",
+      "item": [
+        {
+          "name": "POST /colecciones/{col_id}/repetidas",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/colecciones/1/repetidas",
+              "host": ["{{base_url}}"],
+              "path": ["colecciones", "1", "repetidas"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "user_id", "value": "1000" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"fig_id\": \"ARG-9\",\n  \"cantidad_disponible\": 2,\n  \"modos_intercambio\": [\"INTERCAMBIO\"]\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 201', () => pm.response.to.have.status(201));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /colecciones/{col_id}/repetidas - figurita inexistente (404)",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/colecciones/1/repetidas",
+              "host": ["{{base_url}}"],
+              "path": ["colecciones", "1", "repetidas"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "user_id", "value": "1000" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"fig_id\": \"XXX-99\",\n  \"cantidad_disponible\": 1,\n  \"modos_intercambio\": [\"SUBASTA\"]\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 404', () => pm.response.to.have.status(404));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US2 - Registrar figurita faltante",
+      "item": [
+        {
+          "name": "POST /colecciones/{col_id}/faltantes",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/colecciones/1/faltantes",
+              "host": ["{{base_url}}"],
+              "path": ["colecciones", "1", "faltantes"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"fig_id\": \"ARG-11\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 201', () => pm.response.to.have.status(201));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US3 - Buscar figuritas con filtros",
+      "item": [
+        {
+          "name": "GET /figuritas (sin filtro)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/figuritas",
+              "host": ["{{base_url}}"],
+              "path": ["figuritas"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Retorna array', () => pm.expect(pm.response.json()).to.be.an('array'));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /figuritas?seleccion=ARGENTINA",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/figuritas?seleccion=ARGENTINA",
+              "host": ["{{base_url}}"],
+              "path": ["figuritas"],
+              "query": [
+                { "key": "seleccion", "value": "ARGENTINA" }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Solo figuritas argentinas', () => {",
+                  "  pm.response.json().forEach(f => pm.expect(f.seleccion).to.eql('ARGENTINA'));",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /figuritas?numero=10",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/figuritas?numero=10",
+              "host": ["{{base_url}}"],
+              "path": ["figuritas"],
+              "query": [
+                { "key": "numero", "value": "10" }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Solo numero 10', () => {",
+                  "  pm.response.json().forEach(f => pm.expect(f.numero).to.eql(10));",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /figuritas?jugador=Messi",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/figuritas?jugador=Messi",
+              "host": ["{{base_url}}"],
+              "path": ["figuritas"],
+              "query": [
+                { "key": "jugador", "value": "Messi" }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Solo Messi', () => {",
+                  "  pm.response.json().forEach(f => pm.expect(f.jugador).to.include('Messi'));",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US4 - Sugerencias de intercambio",
+      "item": [
+        {
+          "name": "GET /usuarios/{user_id}/sugerencias",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/usuarios/1000/sugerencias",
+              "host": ["{{base_url}}"],
+              "path": ["usuarios", "1000", "sugerencias"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 202', () => pm.response.to.have.status(202));",
+                  "pm.test('Retorna array de sugerencias', () => {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json).to.be.an('array');",
+                  "  if (json.length > 0) {",
+                  "    pm.expect(json[0]).to.have.property('usuario');",
+                  "    pm.expect(json[0]).to.have.property('figuritas');",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US5 - Propuesta de intercambio",
+      "item": [
+        {
+          "name": "POST /propuestas",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/propuestas",
+              "host": ["{{base_url}}"],
+              "path": ["propuestas"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"usuario_origen_id\": \"1002\",\n  \"usuario_destino_id\": \"1000\",\n  \"figurita_buscada_id\": \"ARG-10\",\n  \"figuritas_ofrecidas_ids\": [\"ARG-9\"]\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 201', () => pm.response.to.have.status(201));",
+                  "pm.test('Propuesta creada con estado PENDIENTE', () => {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.estado).to.eql('PENDIENTE');",
+                  "  pm.expect(json.id).to.not.be.null;",
+                  "});",
+                  "if (pm.response.code === 201) {",
+                  "  pm.collectionVariables.set('propuesta_id', pm.response.json().id);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /propuestas - usuario inexistente (404)",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/propuestas",
+              "host": ["{{base_url}}"],
+              "path": ["propuestas"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"usuario_origen_id\": \"xxx\",\n  \"usuario_destino_id\": \"1001\",\n  \"figurita_buscada_id\": \"ARG-10\",\n  \"figuritas_ofrecidas_ids\": [\"ARG-10\"]\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 404', () => pm.response.to.have.status(404));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US6 - Publicar figurita en subasta",
+      "item": [
+        {
+          "name": "POST /subastas",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/subastas",
+              "host": ["{{base_url}}"],
+              "path": ["subastas"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "user_id", "value": "1001" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"figurita_id\": \"ARG-10\",\n  \"duracion\": 60\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Subasta creada con datos', () => {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json).to.have.property('usuario');",
+                  "  pm.expect(json).to.have.property('duracion');",
+                  "  pm.expect(json).to.have.property('figurita');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US7 - Ofertar en subasta activa",
+      "item": [
+        {
+          "name": "POST /subastas/{sub_id}/propuestas",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/subastas/3000/propuestas",
+              "host": ["{{base_url}}"],
+              "path": ["subastas", "3000", "propuestas"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "user_id", "value": "1000" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"usuario_id\": \"1001\",\n  \"figuritas_ofrecidas\": [\"ARG-10\", \"ARG-11\"]\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Subasta con propuesta ganadora', () => {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json).to.have.property('propuesta_ganadora');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /subastas/{sub_id}/propuestas - figuritas repetidas (400)",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/subastas/3000/propuestas",
+              "host": ["{{base_url}}"],
+              "path": ["subastas", "3000", "propuestas"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "user_id", "value": "1000" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"usuario_id\": \"1001\",\n  \"figuritas_ofrecidas\": [\"ARG-10\", \"ARG-10\"]\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 400', () => pm.response.to.have.status(400));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US8 - Ver operaciones del usuario",
+      "item": [
+        {
+          "name": "GET /usuarios/{user_id}/operaciones",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/usuarios/1000/operaciones",
+              "host": ["{{base_url}}"],
+              "path": ["usuarios", "1000", "operaciones"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Tiene todas las secciones', () => {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json).to.have.property('figuritas_publicadas');",
+                  "  pm.expect(json).to.have.property('propuestas_enviadas');",
+                  "  pm.expect(json).to.have.property('propuestas_recibidas');",
+                  "  pm.expect(json).to.have.property('subastas_activas');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /usuarios/{user_id}/operaciones - inexistente (404)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/usuarios/u-99/operaciones",
+              "host": ["{{base_url}}"],
+              "path": ["usuarios", "u-99", "operaciones"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 404', () => pm.response.to.have.status(404));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US9 - Aceptar o rechazar propuestas",
+      "item": [
+        {
+          "name": "PATCH /propuestas/{prop_id}/aceptar",
+          "request": {
+            "method": "PATCH",
+            "url": {
+              "raw": "{{base_url}}/propuestas/2000/aceptar",
+              "host": ["{{base_url}}"],
+              "path": ["propuestas", "2000", "aceptar"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 204', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PATCH /propuestas/{prop_id}/rechazar",
+          "request": {
+            "method": "PATCH",
+            "url": {
+              "raw": "{{base_url}}/propuestas/{{propuesta_id}}/rechazar",
+              "host": ["{{base_url}}"],
+              "path": ["propuestas", "{{propuesta_id}}", "rechazar"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 204', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US10 - Calificar usuario",
+      "item": [
+        {
+          "name": "POST /usuarios/{user_id}/calificaciones",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/usuarios/1000/calificaciones",
+              "host": ["{{base_url}}"],
+              "path": ["usuarios", "1000", "calificaciones"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"calificacion\": 8\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /usuarios/{user_id}/calificaciones - invalida (400)",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/usuarios/1000/calificaciones",
+              "host": ["{{base_url}}"],
+              "path": ["usuarios", "1000", "calificaciones"]
+            },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"calificacion\": 15\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 400', () => pm.response.to.have.status(400));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US11 - Notificaciones",
+      "item": [
+        {
+          "name": "GET /usuarios/{user_id}/notificaciones",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/usuarios/1000/notificaciones",
+              "host": ["{{base_url}}"],
+              "path": ["usuarios", "1000", "notificaciones"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Retorna array', () => pm.expect(pm.response.json()).to.be.an('array'));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "US12 - Admin estadisticas",
+      "item": [
+        {
+          "name": "GET /administrador/estadisticas",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/administrador/estadisticas",
+              "host": ["{{base_url}}"],
+              "path": ["administrador", "estadisticas"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Tiene campos de estadisticas', () => {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json).to.have.property('total_usuarios');",
+                  "  pm.expect(json).to.have.property('total_figuritas_publicadas');",
+                  "  pm.expect(json).to.have.property('total_propuestas');",
+                  "  pm.expect(json).to.have.property('total_subastas_activas');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Usuarios - Intercambiables",
+      "item": [
+        {
+          "name": "GET /usuarios/{user_id}/intercambiables",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/usuarios/1000/intercambiables",
+              "host": ["{{base_url}}"],
+              "path": ["usuarios", "1000", "intercambiables"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Retorna array', () => pm.expect(pm.response.json()).to.be.an('array'));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /usuarios/{user_id}/intercambiables - inexistente (404)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/usuarios/u-99/intercambiables",
+              "host": ["{{base_url}}"],
+              "path": ["usuarios", "u-99", "intercambiables"]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 404', () => pm.response.to.have.status(404));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/app/model/entities/Coleccion.java
+++ b/src/main/java/app/model/entities/Coleccion.java
@@ -1,11 +1,11 @@
 package app.model.entities;
 
 import app.exceptions.FiguritaDuplicadaException;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Setter
@@ -20,14 +20,22 @@ public class Coleccion {
     this.id = id;
   }
 
+  /**
+   * Agrega una figurita a la lista de faltantes.
+   * Lanza {@link FiguritaDuplicadaException} si ya está registrada como faltante.
+   */
   public void agregarFaltante(Figurita faltante) {
-    if(tieneFaltante(faltante)) {
+    if (tieneFaltante(faltante)) {
       throw new FiguritaDuplicadaException("Figurita ya listada como faltante");
     }
 
     this.faltantes.add(faltante);
   }
 
+  /**
+   * Agrega una figurita repetida a la colección. Si ya existe una entrada para
+   * esa figurita, acumula la cantidad en lugar de crear una entrada duplicada.
+   */
   public void agregarRepetida(FiguritaIntercambiable repetida) {
 
     for (FiguritaIntercambiable f : repetidas) {

--- a/src/main/java/app/model/entities/MedioDeContacto.java
+++ b/src/main/java/app/model/entities/MedioDeContacto.java
@@ -1,8 +1,10 @@
 package app.model.entities;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor
+@Getter
 public class MedioDeContacto {
   private MedioComunicacion medioComunicacion;
   private String valor;

--- a/src/main/java/app/model/entities/MetodoIntercambio.java
+++ b/src/main/java/app/model/entities/MetodoIntercambio.java
@@ -5,6 +5,10 @@ public enum MetodoIntercambio {
   INTERCAMBIO,
   SUBASTA_E_INTERCAMBIO;
 
+  /**
+   * Convierte un string al enum correspondiente (case-insensitive).
+   * Lanza {@link IllegalArgumentException} si el valor no coincide con ningún método.
+   */
   public static MetodoIntercambio fromString(String value) {
     for (MetodoIntercambio metodo : MetodoIntercambio.values()) {
       if (metodo.name().equalsIgnoreCase(value)) {

--- a/src/main/java/app/model/entities/Perfil.java
+++ b/src/main/java/app/model/entities/Perfil.java
@@ -16,6 +16,10 @@ public class Perfil {
     private List<MedioDeContacto> mediosDeContacto;
     private List<Calificacion> calificaciones;
 
+    /**
+     * Calcula el promedio de las calificaciones recibidas.
+     * Retorna 0 si el perfil aún no tiene calificaciones.
+     */
     public Float obtenerCalificacionMedia() {
         return (float) calificaciones.stream()
             .mapToInt(Calificacion::getValor)

--- a/src/main/java/app/model/entities/Propuesta.java
+++ b/src/main/java/app/model/entities/Propuesta.java
@@ -34,6 +34,10 @@ public class Propuesta {
     //Valído que no este pendiente y que solo lo pueda aceptar el usuario Correspondiente.
     //Chequear si eso está bien o no es necesario.
 
+    /**
+     * Retorna el estado más reciente de la propuesta. Si la lista está vacía
+     * (puede ocurrir al deserializar), inicializa con PENDIENTE.
+     */
     public EstadoPropuesta obtenerEstadoActual() {
         if (estado == null || estado.isEmpty()) {
             EstadoPropuesta inicial = new EstadoPropuesta(LocalDateTime.now(), EstadoProceso.PENDIENTE);
@@ -43,12 +47,21 @@ public class Propuesta {
         }
         return estado.get(estado.size() - 1);
     }
+
+    /**
+     * Acepta la propuesta. Valida que {@code usuario} sea el destinatario
+     * y que la propuesta esté en estado PENDIENTE.
+     */
     public void aceptar(Perfil usuario) {
         validarUsuarioDestino(usuario);
         validarPendiente();
         estado.add(new EstadoPropuesta(LocalDateTime.now(), EstadoProceso.ACEPTADO));
     }
 
+    /**
+     * Rechaza la propuesta. Valida que {@code usuario} sea el destinatario
+     * y que la propuesta esté en estado PENDIENTE.
+     */
     public void rechazar(Perfil usuario) {
         validarUsuarioDestino(usuario);
         validarPendiente();

--- a/src/main/java/app/model/entities/Subasta.java
+++ b/src/main/java/app/model/entities/Subasta.java
@@ -2,7 +2,6 @@ package app.model.entities;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,7 +22,7 @@ public class Subasta {
     private Boolean finalizada;
 
     public Subasta(String id, Perfil autor, LocalDateTime fechaInicio, LocalDateTime fechaCierre,
-                   Figurita figuritaSubastada,List<Figurita> figuritasSolicitadas,
+                   Figurita figuritaSubastada, List<Figurita> figuritasSolicitadas,
                    Integer calificacionMinimaSolicitada) {
         this.id = id;
         this.autor = autor;
@@ -47,18 +46,20 @@ public class Subasta {
         this.calificacionMinimaSolicitada = 0;
     }
 
+    /**
+     * Retorna {@code true} si la subasta está dentro de su ventana de tiempo
+     */
     public Boolean estaActivo() {
         final LocalDateTime fechaActual = LocalDateTime.now();
 
-        return fechaActual.isAfter(fechaInicio)
-            && fechaActual.isBefore(fechaCierre);
+        return fechaActual.isAfter(fechaInicio) && fechaActual.isBefore(fechaCierre);
 //            && ofertas.stream()
 //            .anyMatch(p ->
 //                p.obtenerEstadoActual().getValor() == EstadoProceso.ACEPTADO
 //            );
     }
-//TODO definir se lo utilizaremos, si finaliza sin que el usuario haya seleccionado
 
+//    TODO definir se lo utilizaremos, si finaliza sin que el usuario haya seleccionado
 //    public void algoritmoSeleccionador(Propuesta propuesta) {
 //        Propuesta propuestaActual = this.propuestaGanadora;
 //

--- a/src/main/java/app/servicios/IColeccionService.java
+++ b/src/main/java/app/servicios/IColeccionService.java
@@ -5,8 +5,17 @@ import app.model.entities.FiguritaIntercambiable;
 import java.util.List;
 
 public interface IColeccionService {
-  void agregarFaltante(String colId, String figId);
-  void agregarRepetida(String colId, String userId, String figId, Integer
-      cantidadDisponible, List<String> modosIntercambio);
 
+    /**
+     * Agrega la figurita indicada a la lista de faltantes de la colección.
+     * Propaga {@link app.exceptions.FiguritaDuplicadaException} si ya está registrada como faltante.
+     */
+    void agregarFaltante(String colId, String figId);
+
+    /**
+     * Agrega una figurita repetida a la colección y notifica a los usuarios
+     * que la tienen en su lista de faltantes.
+     */
+    void agregarRepetida(String colId, String userId, String figId, Integer
+        cantidadDisponible, List<String> modosIntercambio);
 }

--- a/src/main/java/app/servicios/IEstadisticasService.java
+++ b/src/main/java/app/servicios/IEstadisticasService.java
@@ -3,5 +3,10 @@ package app.servicios;
 import app.dto.EstadisticasDto;
 
 public interface IEstadisticasService {
+
+    /**
+     * Retorna estadísticas globales: total de usuarios, figuritas publicadas
+     * (suma de repetidas de todas las colecciones), propuestas y subastas activas.
+     */
     EstadisticasDto obtenerEstadisticas();
 }

--- a/src/main/java/app/servicios/IFiguritaService.java
+++ b/src/main/java/app/servicios/IFiguritaService.java
@@ -5,6 +5,11 @@ import app.model.entities.Seleccion;
 import java.util.List;
 
 public interface IFiguritaService {
-  public List<FiguritaIntercambiableDto> buscarFiguritas (Integer numero, Seleccion seleccion,
-                                                          String jugador);
+
+    /**
+     * Busca figuritas intercambiables aplicando filtros opcionales por número, selección y jugador.
+     * Primero filtra en el repositorio de figuritas y luego cruza con las intercambiables disponibles.
+     */
+    List<FiguritaIntercambiableDto> buscarFiguritas(Integer numero, Seleccion seleccion,
+                                                    String jugador);
 }

--- a/src/main/java/app/servicios/INotificacionService.java
+++ b/src/main/java/app/servicios/INotificacionService.java
@@ -4,5 +4,10 @@ import app.model.entities.Perfil;
 import java.util.List;
 
 public interface INotificacionService {
-  public void notificarInteresados(List<Perfil> interesados, String cuerpo);
+
+    /**
+     * Persiste una notificación por cada perfil interesado.
+     * Por ahora almacena en memoria; en el futuro se integrará con el adaptador de Telegram.
+     */
+    void notificarInteresados(List<Perfil> interesados, String cuerpo);
 }

--- a/src/main/java/app/servicios/IPerfilService.java
+++ b/src/main/java/app/servicios/IPerfilService.java
@@ -10,11 +10,32 @@ import app.model.entities.Calificacion;
 import java.util.List;
 
 public interface IPerfilService {
+
+    /**
+     * Retorna el resumen de operaciones del perfil: figuritas publicadas,
+     * propuestas enviadas, propuestas recibidas y subastas activas.
+     * Retorna {@code null} si el perfil no existe.
+     */
     OperacionesDto obtenerOperacionesPerfil(String userId);
 
+    /**
+     * Retorna las figuritas intercambiables del perfil.
+     * Lanza {@link app.exceptions.NotFoundException} si el perfil no existe.
+     */
     List<FiguritaIntercambiableDto> obtenerIntercambiablesPerfil(String userId);
+
+    /**
+     * Agrega una calificación de {@code autor} al perfil destino y retorna el nuevo promedio.
+     * Valida que el valor esté entre 1 y 5 inclusive.
+     */
     CalificacionDto agregarCalificacion(String autorId, String perfilDestinoId, Integer valor,
                                         String descripcion);
+
+    /**
+     * Sugiere perfiles que tienen repetidas figuritas que le faltan al usuario.
+     * Recorre todos los perfiles y cruza sus repetidas contra los faltantes del usuario objetivo.
+     */
     List<SugerenciaDto> obtenerSugerencias(String userId);
+
     List<NotificacionesDto> obtenerNotificaciones(String userId);
 }

--- a/src/main/java/app/servicios/IPropuestaService.java
+++ b/src/main/java/app/servicios/IPropuestaService.java
@@ -5,7 +5,22 @@ import app.dto.request.CrearPropuestaRequest;
 import app.model.entities.Propuesta;
 
 public interface IPropuestaService {
+
+    /**
+     * Crea una propuesta de intercambio. Valida que el usuario origen,
+     * destino y figuritas existan. El estado inicial es PENDIENTE.
+     */
     PropuestaDto crearPropuesta(CrearPropuestaRequest request);
+
+    /**
+     * Acepta la propuesta. Resuelve el perfil a partir del {@code usuarioId}
+     * y delega la validación de permisos y estado en {@link app.model.entities.Propuesta#aceptar}.
+     */
     void aceptar(String id, String usuarioId);
+
+    /**
+     * Rechaza la propuesta. Resuelve el perfil a partir del {@code usuarioId}
+     * y delega la validación de permisos y estado en {@link app.model.entities.Propuesta#rechazar}.
+     */
     void rechazar(String id, String usuarioId);
 }

--- a/src/main/java/app/servicios/ISubastaService.java
+++ b/src/main/java/app/servicios/ISubastaService.java
@@ -9,9 +9,18 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ISubastaService {
-  SubastaDto crearSubasta(String userId, LocalDateTime fechaInicio, LocalDateTime fechaFin,
-                          String figuritaSubastadaId);
 
-  SubastaDto ofertarEnSubasta(String userId, String usuarioDestinoId,
-                               String subastaId, List<String> rawFiguritasId);
+    /**
+     * Crea una subasta para la figurita indicada y notifica a los usuarios
+     * que la tienen en su lista de faltantes.
+     */
+    SubastaDto crearSubasta(String userId, LocalDateTime fechaInicio, LocalDateTime fechaFin,
+                            String figuritaSubastadaId);
+
+    /**
+     * Registra una oferta en la subasta. Valida que no haya figuritas ofrecidas duplicadas
+     * y crea una propuesta asociada a la subasta.
+     */
+    SubastaDto ofertarEnSubasta(String userId, String usuarioDestinoId,
+                                String subastaId, List<String> rawFiguritasId);
 }

--- a/src/main/java/app/servicios/impl/ColeccionService.java
+++ b/src/main/java/app/servicios/impl/ColeccionService.java
@@ -1,14 +1,17 @@
 package app.servicios.impl;
 
-import app.model.entities.*;
+import app.model.entities.Coleccion;
+import app.model.entities.Figurita;
+import app.model.entities.FiguritaIntercambiable;
+import app.model.entities.MetodoIntercambio;
+import app.model.entities.Perfil;
 import app.repositories.RepositorioColecciones;
 import app.repositories.RepositorioFiguritas;
 import app.repositories.RepositorioPerfiles;
 import app.servicios.IColeccionService;
 import app.servicios.INotificacionService;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
+import org.springframework.stereotype.Service;
 
 @Service
 public class ColeccionService implements IColeccionService {
@@ -29,6 +32,7 @@ public class ColeccionService implements IColeccionService {
     this.notificacionService = notificacionService;
   }
 
+  @Override
   public void agregarFaltante(String colId, String figId) {
     Coleccion coleccion = this.repositorioColecciones.buscarPorId(colId);
 
@@ -39,6 +43,7 @@ public class ColeccionService implements IColeccionService {
     repositorioColecciones.guardar(coleccion);
   }
 
+  @Override
   public void agregarRepetida(String colId, String usuarioId, String figId, Integer
       cantidadExistente, List<String> modosIntercambio) {
     Coleccion coleccion = this.repositorioColecciones.buscarPorId(colId);

--- a/src/main/java/app/servicios/impl/FiguritaService.java
+++ b/src/main/java/app/servicios/impl/FiguritaService.java
@@ -22,6 +22,7 @@ public class FiguritaService implements IFiguritaService {
     this.repositorioFiguritas = repositorioFiguritas;
   }
 
+  @Override
   public List<FiguritaIntercambiableDto> buscarFiguritas(
       Integer numero, Seleccion seleccion, String jugador) {
 

--- a/src/main/java/app/servicios/impl/NotificacionService.java
+++ b/src/main/java/app/servicios/impl/NotificacionService.java
@@ -16,6 +16,7 @@ public class NotificacionService implements INotificacionService {
 
   private final RepositorioNotificaciones repositorioNotificaciones;
 
+  @Override
   public void notificarInteresados(List<Perfil> interesados, String cuerpo) {
     interesados.forEach(u -> {
       Mensaje mensaje = new Mensaje(cuerpo, LocalDateTime.now());

--- a/src/main/java/app/servicios/impl/PerfilService.java
+++ b/src/main/java/app/servicios/impl/PerfilService.java
@@ -65,7 +65,7 @@ public class PerfilService implements IPerfilService {
 
         return new OperacionesDto(figuritasPublicadas, enviadas, recibidas, subastasActivas);
     }
-//para cuando quiere realizar una propuesta
+
     @Override
     public List<FiguritaIntercambiableDto> obtenerIntercambiablesPerfil(String userId) {
         Perfil perfil = repositorioPerfiles.buscarPorId(userId);
@@ -76,6 +76,8 @@ public class PerfilService implements IPerfilService {
             .map(FiguritaIntercambiableDto::new)
             .toList();
     }
+
+    @Override
     public CalificacionDto agregarCalificacion(String autorId, String perfilDestinoId, Integer valor, String descripcion) {
         if (valor == null) {
             throw new BadRequestException("El valor de la calificación no puede ser nulo");
@@ -123,6 +125,7 @@ public class PerfilService implements IPerfilService {
         return sugerencias.stream().map(SugerenciaDto::new).toList();
     }
 
+    @Override
     public List<NotificacionesDto> obtenerNotificaciones(String userId) {
         Perfil perfil = repositorioPerfiles.buscarPorId(userId);
 

--- a/src/main/java/app/servicios/impl/PropuestaService.java
+++ b/src/main/java/app/servicios/impl/PropuestaService.java
@@ -37,10 +37,7 @@ public class PropuestaService implements IPropuestaService {
     this.notificacionService = notificacionService;
   }
 
-  /**
-   * Crea una propuesta de intercambio. Valida que el usuario origen,
-   * destino y figuritas existan. El estado inicial es PENDIENTE.
-   */
+  @Override
   public PropuestaDto crearPropuesta(CrearPropuestaRequest request) {
     Perfil origen  = repositorioPerfiles.buscarPorId(request.getAutorId());
     Perfil destino = repositorioPerfiles.buscarPorId(request.getDestinatarioId());
@@ -73,6 +70,8 @@ public class PropuestaService implements IPropuestaService {
 
     return new PropuestaDto(propuesta);
   }
+
+  @Override
   public void aceptar(String propuestaId, String usuarioId) {
     Propuesta propuesta = repositorioPropuestas.buscarPorId(propuestaId);
     Perfil perfil = repositorioPerfiles.buscarPorUsuarioId(usuarioId);
@@ -80,6 +79,7 @@ public class PropuestaService implements IPropuestaService {
     repositorioPropuestas.guardar(propuesta);
   }
 
+  @Override
   public void rechazar(String id, String usuarioId) {
     Propuesta propuesta = repositorioPropuestas.buscarPorId(id);
     Perfil perfil = repositorioPerfiles.buscarPorUsuarioId(usuarioId);

--- a/src/main/java/app/servicios/impl/SubastaServiceImpl.java
+++ b/src/main/java/app/servicios/impl/SubastaServiceImpl.java
@@ -2,22 +2,20 @@ package app.servicios.impl;
 
 import app.dto.SubastaDto;
 import app.exceptions.BadRequestException;
-import app.model.entities.EstadoProceso;
 import app.model.entities.Figurita;
+import app.model.entities.Perfil;
 import app.model.entities.Propuesta;
 import app.model.entities.Subasta;
-import app.model.entities.Perfil;
 import app.repositories.RepositorioFiguritas;
+import app.repositories.RepositorioPerfiles;
 import app.repositories.RepositorioPropuestas;
 import app.repositories.RepositorioSubastas;
-import app.repositories.RepositorioPerfiles;
 import app.servicios.INotificacionService;
 import app.servicios.ISubastaService;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 public class SubastaServiceImpl implements ISubastaService {
@@ -65,9 +63,9 @@ public class SubastaServiceImpl implements ISubastaService {
   @Override
   public SubastaDto ofertarEnSubasta(String userId, String perfilDestinoId,
                                      String subastaId, List<String> rawFiguritasId) {
-    Perfil autor        = this.repositorioPerfiles.buscarPorUsuarioId(userId);
+    Perfil autor = this.repositorioPerfiles.buscarPorUsuarioId(userId);
     Perfil destinatario = this.repositorioPerfiles.buscarPorId(perfilDestinoId);
-    Subasta subasta     = this.repoSubasta.buscarPorId(subastaId);
+    Subasta subasta = this.repoSubasta.buscarPorId(subastaId);
 
     Figurita figuritaBuscada = subasta.getFiguritaSubastada();
 

--- a/src/test/java/app/controllers/ColeccionControllerTest.java
+++ b/src/test/java/app/controllers/ColeccionControllerTest.java
@@ -1,8 +1,13 @@
 package app.controllers;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import app.exceptions.FiguritaDuplicadaException;
 import app.exceptions.NotFoundException;
-import app.model.entities.*;
 import app.servicios.impl.ColeccionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,28 +17,19 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @SpringBootTest
 @AutoConfigureMockMvc
 class ColeccionControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+  @Autowired
+  MockMvc mockMvc;
 
-    @MockBean
-    private ColeccionService serviceColeccion;
+  @MockBean
+  private ColeccionService serviceColeccion;
 
-    @Test
-    void agregarRepetidaNoFalla() throws Exception {
-        String json = """
+  @Test
+  void agregarRepetidaNoFalla() throws Exception {
+    String json = """
         {
             "fig_id": "ARG-10",
             "cantidad_disponible": 2,
@@ -41,52 +37,52 @@ class ColeccionControllerTest {
         }
         """;
 
-        mockMvc.perform(post("/colecciones/1/repetidas")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("user_id", "user-123")
-                .content(json))
-            .andExpect(status().is(201));
-    }
+    mockMvc.perform(post("/colecciones/1/repetidas")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("user_id", "user-123")
+            .content(json))
+        .andExpect(status().is(201));
+  }
 
-    @Test
-    void agregarFaltanteNoFalla() throws Exception {
-        String json = """
+  @Test
+  void agregarFaltanteNoFalla() throws Exception {
+    String json = """
         {
             "fig_id": "ARG-10"
         }
         """;
 
-        mockMvc.perform(post("/colecciones/1/faltantes")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
-            .andExpect(status().is(201));
-    }
+    mockMvc.perform(post("/colecciones/1/faltantes")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+        .andExpect(status().is(201));
+  }
 
-    @Test
-    void agregarFaltanteNoEncontradaDevuelve404() throws Exception {
-        doThrow(new NotFoundException("No se encontro la figurita"))
-            .when(serviceColeccion)
-            .agregarFaltante("1", "ARG-10");
+  @Test
+  void agregarFaltanteNoEncontradaDevuelve404() throws Exception {
+    doThrow(new NotFoundException("No se encontro la figurita"))
+        .when(serviceColeccion)
+        .agregarFaltante("1", "ARG-10");
 
-        String json = """
+    String json = """
         {
             "fig_id": "ARG-10"
         }
         """;
 
-        mockMvc.perform(post("/colecciones/1/faltantes")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
-            .andExpect(status().is(404));
-    }
+    mockMvc.perform(post("/colecciones/1/faltantes")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+        .andExpect(status().is(404));
+  }
 
-    @Test
-    void agregarRepetidaNoEncontradaDevuelve404() throws Exception {
-        doThrow(new NotFoundException("No se encontro la figurita"))
-            .when(serviceColeccion)
-            .agregarRepetida(eq("1"), any(), any(), any(), any());
+  @Test
+  void agregarRepetidaNoEncontradaDevuelve404() throws Exception {
+    doThrow(new NotFoundException("No se encontro la figurita"))
+        .when(serviceColeccion)
+        .agregarRepetida(eq("1"), any(), any(), any(), any());
 
-        String json = """
+    String json = """
         {
             "fig_id": "ARG-10",
             "cantidad_disponible": 2,
@@ -94,28 +90,28 @@ class ColeccionControllerTest {
         }
         """;
 
-        mockMvc.perform(post("/colecciones/1/repetidas")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("user_id", "user-123")
-                .content(json))
-            .andExpect(status().isNotFound());
-    }
+    mockMvc.perform(post("/colecciones/1/repetidas")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("user_id", "user-123")
+            .content(json))
+        .andExpect(status().isNotFound());
+  }
 
-    @Test
-    void agregarFaltanteDevuelve400SiDuplicada() throws Exception {
-        doThrow(new FiguritaDuplicadaException("Figurita ya listada como faltante"))
-            .when(serviceColeccion)
-            .agregarFaltante(eq("1"), any());
+  @Test
+  void agregarFaltanteDevuelve400SiDuplicada() throws Exception {
+    doThrow(new FiguritaDuplicadaException("Figurita ya listada como faltante"))
+        .when(serviceColeccion)
+        .agregarFaltante(eq("1"), any());
 
-        String json = """
+    String json = """
         {
             "fig_id": "ARG-10"
         }
         """;
 
-        mockMvc.perform(post("/colecciones/1/faltantes")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
-            .andExpect(status().is(400));
-    }
+    mockMvc.perform(post("/colecciones/1/faltantes")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+        .andExpect(status().is(400));
+  }
 }

--- a/src/test/java/app/controllers/PerfilControllerTest.java
+++ b/src/test/java/app/controllers/PerfilControllerTest.java
@@ -1,64 +1,71 @@
 package app.controllers;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @SpringBootTest
 @AutoConfigureMockMvc
 class PerfilControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
-//TODO la logica va a cambiar, revisar test
-//    @Test
-//    void getOperaciones_usuarioExistente_retorna200ConDatos() throws Exception {
-//        mockMvc.perform(get("/perfil/1000/operaciones"))
-//            .andExpect(status().isOk())
-//            .andExpect(jsonPath("$.figuritas_publicadas").isArray())
-//            .andExpect(jsonPath("$.propuestas_enviadas").isArray())
-//            .andExpect(jsonPath("$.propuestas_recibidas").isArray())
-//            .andExpect(jsonPath("$.subastas_activas").isArray());
-//    }
-//
-//    @Test
-//    void getOperaciones_usuarioInexistente_retorna404() throws Exception {
-//        mockMvc.perform(get("/perfil/u-99/operaciones"))
-//            .andExpect(status().isNotFound());
-//    }
+  @Autowired
+  MockMvc mockMvc;
 
-    @Test
-    void calificarUsuarioNoFalla() throws Exception {
-        mockMvc.perform(post("/perfil/1000/calificaciones")
-                .header("autor_id", "1001")
-                .contentType("application/json")
-                .content("{ \"valor\": 4, \"descripcion\": \"Buen intercambio\" }"))
-            .andExpect(status().isOk());
-    }
+  @Test
+  void getOperaciones_usuarioExistente_retorna200ConDatos() throws Exception {
+    mockMvc.perform(get("/perfil/1000/operaciones"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.figuritas_publicadas").isArray())
+        .andExpect(jsonPath("$.propuestas_enviadas").isArray())
+        .andExpect(jsonPath("$.propuestas_recibidas").isArray())
+        .andExpect(jsonPath("$.subastas_activas").isArray());
+  }
+
+  @Test
+  void getOperaciones_usuarioInexistente_retorna404() throws Exception {
+    mockMvc.perform(get("/perfil/u-inexistente/operaciones"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void getSugerencias_retorna200() throws Exception {
+    mockMvc.perform(get("/perfil/1000/sugerencias"))
+        .andExpect(status().is2xxSuccessful());
+  }
+
+  @Test
+  void getNotificaciones_retorna200() throws Exception {
+    mockMvc.perform(get("/perfil/1000/notificaciones"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void calificarUsuarioNoFalla() throws Exception {
+    mockMvc.perform(post("/perfil/1000/calificaciones")
+            .header("autor_id", "1001")
+            .contentType("application/json")
+            .content("{ \"valor\": 4, \"descripcion\": \"Buen intercambio\" }"))
+        .andExpect(status().isOk());
+  }
 
 
-//    @Test
-//    void getNotificaciones() throws Exception {
-//        mockMvc.perform(get("/usuarios/u-99/notificaciones")).andExpect(status().isOk());
-//    }
+  @Test
+  void getIntercambiables_usuarioExistente_retorna200() throws Exception {
+    mockMvc.perform(get("/perfil/1000/intercambiables"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray());
+  }
 
-    @Test
-    void getIntercambiables_usuarioExistente_retorna200() throws Exception {
-        mockMvc.perform(get("/perfil/1000/intercambiables"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$").isArray());
-    }
-
-    @Test
-    void getIntercambiables_usuarioInexistente_retorna404() throws Exception {
-        mockMvc.perform(get("/perfil/u-99/intercambiables"))
-            .andExpect(status().isNotFound());
-    }
+  @Test
+  void getIntercambiables_usuarioInexistente_retorna404() throws Exception {
+    mockMvc.perform(get("/perfil/u-99/intercambiables"))
+        .andExpect(status().isNotFound());
+  }
 }

--- a/src/test/java/app/model/entities/FiguritaIntercambiableTest.java
+++ b/src/test/java/app/model/entities/FiguritaIntercambiableTest.java
@@ -1,0 +1,82 @@
+package app.model.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FiguritaIntercambiableTest {
+
+  private FiguritaIntercambiable fi;
+
+  @BeforeEach
+  void setUp() {
+    Figurita messi = new Figurita("ARG-10", 10, "Messi", Seleccion.ARGENTINA);
+    fi = new FiguritaIntercambiable(messi, 3, List.of(MetodoIntercambio.INTERCAMBIO));
+  }
+
+  @Test
+  void hayCantidadDisponible_cuandoHayStock_retornaTrue() {
+    assertTrue(fi.hayCantidadDisponible());
+  }
+
+  @Test
+  void hayCantidadDisponible_cuandoTodoReservado_retornaFalse() {
+    fi.reservarFiguritaIntercambiable();
+    fi.reservarFiguritaIntercambiable();
+    fi.reservarFiguritaIntercambiable();
+    assertFalse(fi.hayCantidadDisponible());
+  }
+
+  @Test
+  void reservar_decrementaDisponibilidad() {
+    fi.reservarFiguritaIntercambiable();
+    assertEquals(1, fi.getCantidadReservada());
+  }
+
+  @Test
+  void reservar_sinStock_lanzaExcepcion() {
+    fi.reservarFiguritaIntercambiable();
+    fi.reservarFiguritaIntercambiable();
+    fi.reservarFiguritaIntercambiable();
+    assertThrows(RuntimeException.class, () -> fi.reservarFiguritaIntercambiable());
+  }
+
+  @Test
+  void eliminarReserva_decrementaReservadas() {
+    fi.reservarFiguritaIntercambiable();
+    fi.eliminarReserva();
+    assertEquals(0, fi.getCantidadReservada());
+  }
+
+  @Test
+  void eliminarReserva_sinReservas_lanzaExcepcion() {
+    assertThrows(RuntimeException.class, () -> fi.eliminarReserva());
+  }
+
+  @Test
+  void cambioConcretado_decrementaStock() {
+    fi.cambioConcretado();
+    assertEquals(2, fi.getCantidadExistente());
+  }
+
+  @Test
+  void cambioConcretado_sinStock_lanzaExcepcion() {
+    fi.cambioConcretado();
+    fi.cambioConcretado();
+    fi.cambioConcretado();
+    assertThrows(RuntimeException.class, () -> fi.cambioConcretado());
+  }
+
+  @Test
+  void cambioConcretado_conReserva_eliminaReserva() {
+    fi.reservarFiguritaIntercambiable();
+    fi.cambioConcretado();
+    assertEquals(0, fi.getCantidadReservada());
+    assertEquals(2, fi.getCantidadExistente());
+  }
+}

--- a/src/test/java/app/model/notificador/NotificadorTest.java
+++ b/src/test/java/app/model/notificador/NotificadorTest.java
@@ -1,0 +1,59 @@
+package app.model.notificador;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import app.model.entities.Coleccion;
+import app.model.entities.MedioComunicacion;
+import app.model.entities.MedioDeContacto;
+import app.model.entities.Perfil;
+import app.model.entities.Rol;
+import app.model.entities.Usuario;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NotificadorTest {
+
+  private Perfil perfil() {
+    return new Perfil("p-1", new Usuario("u-1", Rol.USUARIO), "Lucas",
+        new Coleccion(), List.of(new MedioDeContacto(MedioComunicacion.TELEGRAM, "@lucas")),
+        new ArrayList<>());
+  }
+
+  @Test
+  void enviarNotificacion_delegaAlAdapter() {
+    AdapterNotificacion adapter = mock(AdapterNotificacion.class);
+    Notificador notificador = new Notificador(adapter);
+    Mensaje mensaje = new Mensaje("Hola", LocalDateTime.now());
+    Perfil perfil = perfil();
+
+    notificador.enviarNotificacion(mensaje, perfil);
+
+    verify(adapter).notificar(mensaje, perfil);
+  }
+
+  @Test
+  void notificacion_guardaMensajeYUsuario() {
+    Mensaje mensaje = new Mensaje("Hola", LocalDateTime.now());
+    Perfil perfil = perfil();
+
+    Notificacion notificacion = new Notificacion(mensaje, perfil);
+
+    assertEquals(mensaje, notificacion.getMensaje());
+    assertEquals(perfil, notificacion.getUsuario());
+  }
+
+  @Test
+  void adapterTelegram_notificar_noLanzaExcepcion() {
+    AdapterTelegram adapter = new AdapterTelegram();
+    Mensaje mensaje = new Mensaje("Hola", LocalDateTime.now());
+
+    assertDoesNotThrow(
+        () -> adapter.notificar(mensaje, perfil())
+    );
+  }
+}

--- a/src/test/java/app/repositories/impl/RepositorioFiguritasEnMemoriaTest.java
+++ b/src/test/java/app/repositories/impl/RepositorioFiguritasEnMemoriaTest.java
@@ -1,13 +1,12 @@
 package app.repositories.impl;
 
-import app.model.entities.Coleccion;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import app.model.entities.Figurita;
 import app.model.entities.Seleccion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RepositorioFiguritasEnMemoriaTest {
 
@@ -24,7 +23,9 @@ public class RepositorioFiguritasEnMemoriaTest {
 
     repositorio.guardar(messi);
 
-    assertThrows(RuntimeException.class, () -> {repositorio.buscarPorId("11");});
+    assertThrows(RuntimeException.class, () -> {
+      repositorio.buscarPorId("11");
+    });
   }
 
   @Test
@@ -34,5 +35,43 @@ public class RepositorioFiguritasEnMemoriaTest {
     repositorio.guardar(messi);
 
     assertEquals(messi.getId(), repositorio.buscarPorId("ARG-10").getId());
+  }
+
+  @Test
+  void buscarConFiltros_porNumero_retornaCoincidencia() {
+    repositorio.guardar(new Figurita("ARG-10", 10, "Messi", Seleccion.ARGENTINA));
+    repositorio.guardar(new Figurita("FRA-7", 7, "Mbappé", Seleccion.FRANCIA));
+
+    var resultado = repositorio.buscarConFiltros(10, null, null);
+
+    assertEquals(1, resultado.size());
+    assertEquals("ARG-10", resultado.get(0).getId());
+  }
+
+  @Test
+  void buscarConFiltros_porSeleccion_retornaCoincidencia() {
+    repositorio.guardar(new Figurita("ARG-10", 10, "Messi", Seleccion.ARGENTINA));
+    repositorio.guardar(new Figurita("FRA-7", 7, "Mbappé", Seleccion.FRANCIA));
+
+    var resultado = repositorio.buscarConFiltros(null, Seleccion.ARGENTINA, null);
+
+    assertEquals(1, resultado.size());
+  }
+
+  @Test
+  void buscarConFiltros_porJugador_retornaCoincidencia() {
+    repositorio.guardar(new Figurita("ARG-10", 10, "Messi", Seleccion.ARGENTINA));
+
+    var resultado = repositorio.buscarConFiltros(null, null, "messi");
+
+    assertEquals(1, resultado.size());
+  }
+
+  @Test
+  void buscarConFiltros_sinResultados_lanzaExcepcion() {
+    repositorio.guardar(new Figurita("ARG-10", 10, "Messi", Seleccion.ARGENTINA));
+
+    assertThrows(RuntimeException.class,
+        () -> repositorio.buscarConFiltros(99, null, null));
   }
 }


### PR DESCRIPTION
# Descripción

## Readme

Se reescribe completamente respondiendo las preguntas del feedback:

- **Stack tecnológico**
- **Cómo levantar la app**
- **Endpoints disponibles** con método HTTP, ruta, headers requeridos y bodies de ejemplo en JSON.
- **Colección de Postman**: referencia al archivo `postman_collection.json` en la raíz con instrucciones de importación y aclaración sobre los IDs de datos precargados.
- **Decisiones de diseño**
---

### Javadoc

Se documenta siguiendo la convención de la industria, el Javadoc vive en las **interfaces** no en las implementaciones.

---

### Cobertura y build

- Umbral de JaCoCo subido de `0` a `80%` por paquete (`PACKAGE`). DTOs excluidos 
- Se agregan tests para cubrir los paquetes que no llegaban al umbral:
- Se agrega `@Override` donde faltaba para prevenir code smells