### PR TITLE
Mejoras de seguridad y optimización del Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,20 @@ COPY src ./src
 RUN mvn verify
 
 # --- Etapa de runtime ---
-# Se usa JRE para ejecutar
-FROM eclipse-temurin:17-jre
+# Se usa JRE Alpine para ejecutar — imagen mas liviana que la estandar
+# forzamos la plataforma linux/amd64 porque eclipse-temurin:alpine no tiene soporte ARM64
+FROM --platform=linux/amd64 eclipse-temurin:17-jre-alpine
 WORKDIR /app
+
+# Creamos un usuario sin privilegios para correr la app
+# Si alguien explota la app, no tiene acceso root al contenedor
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 # Copiamos el JAR
 COPY --from=build /app/target/*.jar app.jar
+
+# Cambiamos al usuario sin privilegios
+USER appuser
 
 # Exponemos el puerto
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@
 FROM maven:3.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
-# Copiamos el pom, la configuración de SpotBugs, la configuracion de lombok y el código fuente
+# Copiamos solo el pom para cachear la descarga de dependencias
+# Si src/ cambia pero pom.xml no, Docker reutiliza esta capa
 COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# Copiamos el resto de archivos de configuración y el código fuente
 COPY spotbugs-exclude.xml .
 COPY lombok.config .
 COPY src ./src

--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Aplicación de intercambio de figuritas del Mundial. Permite a los usuarios gest
 
 ## Levantar la aplicación
 
-### Con Docker (recomendado)
+### Con Docker Compose
+
+```bash
+docker compose up
+```
+
+### Con Docker
 
 ```bash
 docker build -t tacs-grupo5 .
@@ -32,6 +38,8 @@ mvn spring-boot:run
 ```
 
 La aplicación queda disponible en `http://localhost:8080`.
+
+---
 
 ## Endpoints disponibles
 


### PR DESCRIPTION
## Descripción

**`.dockerignore`:** excluye `target/` y `.git/` para no enviarlos al daemon en cada build.

**Imagen Alpine:** reemplaza `eclipse-temurin:17-jre` por `eclipse-temurin:17-jre-alpine`, reduciendo el tamaño de la imagen final y la superficie de ataque. Se fuerza `--platform=linux/amd64` porque la imagen Alpine no tiene soporte ARM64 (Apple silicon).

**Usuario sin privilegios:** el proceso corre como `appuser` en lugar de root. El JAR se deja con owner root para que `appuser` no pueda sobreescribirlo — si un atacante explota la app, no puede reemplazar el JAR con código malicioso.

**Layer caching:** se separa `dependency:go-offline` de `mvn verify` para que cambios en `src/` no re-descarguen todas las dependencias. Solo un cambio en `pom.xml` invalida esa capa.
