### PR TITLE
Remover ruta duplicada

### DIFF
--- a/frontend/src/app-routes.jsx
+++ b/frontend/src/app-routes.jsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes } from 'react-router-dom'
 import Layout from './components/layouts/layout/layout'
 import MisFiguritas from './views/public/mis-figuritas/mis-figuritas.jsx'
 import NuevaFaltante from './views/public/nueva-faltante/nueva-faltante.jsx'
@@ -22,12 +22,11 @@ import ServidorCaido from '@/views/public/errores/servidor-caido/servidor-caido.
 import ErrorInterno from '@/views/public/errores/error-interno/error-interno.jsx'
 import CrearOferta from './views/public/crear-oferta/crear-oferta.jsx'
 import EditarOferta from './views/public/editar-oferta/editar-oferta.jsx'
-import Administrador from './views/public/administrador/administrador.jsx'
 
 const publics = [
   {
     path: '/',
-    element: <Explorar />,
+    element: <Navigate to="/explorar" replace />,
   },
   {
     path: '/explorar',


### PR DESCRIPTION
# Limpiar rutas duplicadas y imports muertos en app-routes
  
Elimina el import sin usar de Administrador y convierte la ruta raíz / en un redirect hacia /explorar para evitar duplicación de lógica y un potencial loop en el historial del navegador.
