### PR TITLE
Feature/solve n+1

### DIFF
--- a/backend/src/main/java/app/dto/FiguritaIntercambiableDto.java
+++ b/backend/src/main/java/app/dto/FiguritaIntercambiableDto.java
@@ -2,10 +2,8 @@ package app.dto;
 
 import app.model.entities.FiguritaIntercambiable;
 import app.model.entities.MetodoIntercambio;
-import app.model.entities.Perfil;
 import app.model.entities.Seleccion;
-import app.model.entities.Subasta;
-import java.util.ArrayList;
+import app.repositories.projections.ResumenPerfil;
 import java.util.List;
 import lombok.Getter;
 
@@ -25,7 +23,7 @@ public class FiguritaIntercambiableDto {
   private String imagenUrl;
   private String subastaId;
 
-  public FiguritaIntercambiableDto(FiguritaIntercambiable f, Perfil perfil, String subastaId) {
+  public FiguritaIntercambiableDto(FiguritaIntercambiable f, ResumenPerfil perfil, String subastaId) {
     this.figuritaId = f.getFigurita().getId();
     this.numero = f.getFigurita().getNumero();
     this.jugador = f.getFigurita().getJugador();
@@ -36,28 +34,16 @@ public class FiguritaIntercambiableDto {
     this.cantidadReservada = f.getCantidadReservada();
     this.metodos = f.getMetodos();
     this.perfilId = f.getPerfilId();
-    this.nombreUsuario = perfil != null ? perfil.getNombre() : null;
-    this.reputacion = perfil != null ? (int) Math.round(perfil.getCalificacionMedia()) : null;
+    this.nombreUsuario = perfil != null ? perfil.nombre() : null;
+    this.reputacion = perfil != null ? (int) Math.round(perfil.calificacionMedia()) : null;
     this.subastaId = subastaId;
   }
 
-  public FiguritaIntercambiableDto(FiguritaIntercambiable f, Perfil perfil) {
-    this.figuritaId = f.getFigurita().getId();
-    this.numero = f.getFigurita().getNumero();
-    this.jugador = f.getFigurita().getJugador();
-    this.seleccion = f.getFigurita().getSeleccion();
-    this.posicion = f.getFigurita().getPosicion();
-    this.imagenUrl = f.getFigurita().getImagenUrl();
-    this.cantidadExistente = f.getCantidadExistente();
-    this.cantidadReservada = f.getCantidadReservada();
-    this.metodos = f.getMetodos();
-    this.perfilId = f.getPerfilId();
-    this.nombreUsuario = perfil != null ? perfil.getNombre() : null;
-    this.reputacion = perfil != null ? (int) Math.round(perfil.getCalificacionMedia()) : null;
-    this.subastaId = null;
+  public FiguritaIntercambiableDto(FiguritaIntercambiable f, ResumenPerfil perfil) {
+    this(f, perfil, null);
   }
 
   public FiguritaIntercambiableDto(FiguritaIntercambiable f) {
-    this(f, null);
+    this(f, null, null);
   }
 }

--- a/backend/src/main/java/app/repositories/RepositorioColecciones.java
+++ b/backend/src/main/java/app/repositories/RepositorioColecciones.java
@@ -6,6 +6,7 @@ import app.model.entities.Coleccion;
 import app.model.entities.Figurita;
 import app.model.entities.FiguritaIntercambiable;
 import app.model.entities.MetodoIntercambio;
+import app.repositories.projections.FiguritaIntercambiableConPerfil;
 import app.dto.filtros.FaltantesFiltro;
 import app.dto.filtros.FiguritasFiltro;
 import app.dto.filtros.RepetidasFiltro;
@@ -27,7 +28,7 @@ public interface RepositorioColecciones {
 
   PaginaResultado<Figurita> buscarFaltantes(String colId, FaltantesFiltro filtros);
 
-  PaginaResultado<FiguritaIntercambiable> buscarIntercambiablesConFiltros(
+  PaginaResultado<FiguritaIntercambiableConPerfil> buscarIntercambiablesConFiltros(
       FiguritasFiltro filtros, int pagina, int tamanioPagina);
 
   /**
@@ -35,7 +36,7 @@ public interface RepositorioColecciones {
    * jugador, selección o número en OR. Entre términos se aplica AND.
    * El filtro {@code tipos} se aplica en AND sobre el resultado.
    */
-  PaginaResultado<FiguritaIntercambiable> buscarIntercambiablesPorQuery(
+  PaginaResultado<FiguritaIntercambiableConPerfil> buscarIntercambiablesPorQuery(
       String q, List<MetodoIntercambio> tipos, int pagina, int tamanioPagina);
 
   List<FiguritaIntercambiable> buscarIntercambiablesPorFiguritaIds(List<String> figuritaIds);

--- a/backend/src/main/java/app/repositories/impl/RepositorioColeccionesMongo.java
+++ b/backend/src/main/java/app/repositories/impl/RepositorioColeccionesMongo.java
@@ -8,6 +8,8 @@ import app.model.entities.Coleccion;
 import app.model.entities.Figurita;
 import app.model.entities.FiguritaIntercambiable;
 import app.model.entities.MetodoIntercambio;
+import app.repositories.projections.FiguritaIntercambiableConPerfil;
+import app.repositories.projections.ResumenPerfil;
 import app.dto.filtros.FaltantesFiltro;
 import app.dto.filtros.FiguritasFiltro;
 import app.dto.filtros.RepetidasFiltro;
@@ -181,7 +183,7 @@ public class RepositorioColeccionesMongo implements RepositorioColecciones {
   }
 
   @Override
-  public PaginaResultado<FiguritaIntercambiable> buscarIntercambiablesConFiltros(
+  public PaginaResultado<FiguritaIntercambiableConPerfil> buscarIntercambiablesConFiltros(
       FiguritasFiltro filtros, int pagina, int limite) {
     List<AggregationOperation> ops = new ArrayList<>();
 
@@ -215,17 +217,19 @@ public class RepositorioColeccionesMongo implements RepositorioColecciones {
       ));
     }
 
-    AggregationResults<Document> resultado = this.buscarCampoEnColeccion(null, "repetidas", ops, pagina, limite);
+    AggregationResults<Document> resultado =
+        this.buscarIntercambiablesConPerfil(ops, pagina, limite);
 
     int count = this.contarCampoEnColeccion(null, "repetidas", ops);
 
-    List<FiguritaIntercambiable> contenido = this.mapearADominio(resultado);
+    List<FiguritaIntercambiableConPerfil> contenido =
+        this.mapearIntercambiablesConPerfil(resultado);
 
     return new PaginaResultado<>(contenido, count, (int) Math.ceil((double) count / limite), pagina);
   }
 
   @Override
-  public PaginaResultado<FiguritaIntercambiable> buscarIntercambiablesPorQuery(
+  public PaginaResultado<FiguritaIntercambiableConPerfil> buscarIntercambiablesPorQuery(
       String q, List<MetodoIntercambio> tipos, int pagina, int limite) {
 
     String[] terminos = q.trim().toLowerCase().split("\\s+");
@@ -255,8 +259,10 @@ public class RepositorioColeccionesMongo implements RepositorioColecciones {
     }
 
     int count = this.contarCampoEnColeccion(null, "repetidas", ops);
-    AggregationResults<Document> resultado = this.buscarCampoEnColeccion(null, "repetidas", ops, pagina, limite);
-    List<FiguritaIntercambiable> contenido = this.mapearADominio(resultado);
+    AggregationResults<Document> resultado =
+        this.buscarIntercambiablesConPerfil(ops, pagina, limite);
+    List<FiguritaIntercambiableConPerfil> contenido =
+        this.mapearIntercambiablesConPerfil(resultado);
 
     return new PaginaResultado<>(contenido, count, (int) Math.ceil((double) count / limite), pagina);
   }
@@ -345,6 +351,36 @@ public class RepositorioColeccionesMongo implements RepositorioColecciones {
     return mongoTemplate.aggregate(aggregation, "colecciones", Document.class);
   }
 
+  private AggregationResults<Document> buscarIntercambiablesConPerfil(
+      List<AggregationOperation> ops,
+      int pagina,
+      int limite
+  ) {
+    List<AggregationOperation> operaciones = new ArrayList<>();
+    operaciones.add(Aggregation.unwind("repetidas"));
+    operaciones.addAll(ops);
+    operaciones.add(Aggregation.skip((long) (pagina - 1) * limite));
+    operaciones.add(Aggregation.limit(limite));
+    operaciones.add(Aggregation.lookup(
+        "perfiles",
+        "repetidas.perfilId",
+        "_id",
+        "perfil"
+    ));
+    operaciones.add(Aggregation.unwind("perfil", true));
+    operaciones.add(Aggregation.project()
+        .and("repetidas").as("figurita")
+        .and("perfil._id").as("perfilId")
+        .and("perfil.nombre").as("perfilNombre")
+        .and("perfil.calificacionMedia").as("perfilCalificacionMedia"));
+
+    return mongoTemplate.aggregate(
+        Aggregation.newAggregation(operaciones),
+        "colecciones",
+        Document.class
+    );
+  }
+
   private int sumarDisponibles(String colId, String campo, List<AggregationOperation> ops) {
     List<AggregationOperation> operaciones = new ArrayList<>();
 
@@ -376,6 +412,44 @@ public class RepositorioColeccionesMongo implements RepositorioColecciones {
         .stream()
         .map(doc -> converter.read(FiguritaIntercambiable.class, doc))
         .toList();
+  }
+
+  private List<FiguritaIntercambiableConPerfil> mapearIntercambiablesConPerfil(
+      AggregationResults<Document> resultado
+  ) {
+    MongoConverter converter = mongoTemplate.getConverter();
+
+    return resultado.getMappedResults().stream()
+        .map(documento -> {
+          FiguritaIntercambiable figurita = converter.read(
+              FiguritaIntercambiable.class,
+              documento.get("figurita", Document.class)
+          );
+
+          return new FiguritaIntercambiableConPerfil(
+              figurita,
+              mapearResumenPerfil(documento)
+          );
+        })
+        .toList();
+  }
+
+  private ResumenPerfil mapearResumenPerfil(Document documento) {
+    Object perfilId = documento.get("perfilId");
+    if (perfilId == null) {
+      return null;
+    }
+
+    Object calificacionMedia = documento.get("perfilCalificacionMedia");
+    double valor = calificacionMedia instanceof Number numero
+        ? numero.doubleValue()
+        : 0.0;
+
+    return new ResumenPerfil(
+        perfilId.toString(),
+        documento.getString("perfilNombre"),
+        valor
+    );
   }
 
   private Integer parseNumero(String termino) {

--- a/backend/src/main/java/app/repositories/projections/FiguritaIntercambiableConPerfil.java
+++ b/backend/src/main/java/app/repositories/projections/FiguritaIntercambiableConPerfil.java
@@ -1,0 +1,9 @@
+package app.repositories.projections;
+
+import app.model.entities.FiguritaIntercambiable;
+
+public record FiguritaIntercambiableConPerfil(
+    FiguritaIntercambiable figurita,
+    ResumenPerfil perfil
+) {
+}

--- a/backend/src/main/java/app/repositories/projections/ResumenPerfil.java
+++ b/backend/src/main/java/app/repositories/projections/ResumenPerfil.java
@@ -1,0 +1,8 @@
+package app.repositories.projections;
+
+public record ResumenPerfil(
+    String id,
+    String nombre,
+    Double calificacionMedia
+) {
+}

--- a/backend/src/main/java/app/servicios/ServicioFigurita.java
+++ b/backend/src/main/java/app/servicios/ServicioFigurita.java
@@ -2,21 +2,17 @@ package app.servicios;
 
 import app.dto.FiguritaDto;
 import app.dto.FiguritaIntercambiableDto;
+import app.dto.filtros.FiguritasFiltro;
 import app.dto.paginacion.PaginaResultado;
-import app.exceptions.NotFoundException;
 import app.model.entities.Figurita;
-import app.model.entities.Subasta;
 import app.model.entities.FiguritaIntercambiable;
 import app.model.entities.MetodoIntercambio;
-import app.model.entities.Perfil;
-import app.dto.filtros.FiguritasFiltro;
+import app.model.entities.Subasta;
 import app.repositories.RepositorioColecciones;
 import app.repositories.RepositorioFiguritas;
-import app.repositories.RepositorioPerfiles;
 import app.repositories.RepositorioSubastas;
+import app.repositories.projections.FiguritaIntercambiableConPerfil;
 import java.util.List;
-
-import app.repositories.impl.campos.CamposPerfil;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +23,6 @@ import org.springframework.stereotype.Service;
 public class ServicioFigurita {
 
   private final RepositorioColecciones repositorioColecciones;
-  private final RepositorioPerfiles repositorioPerfiles;
   private final RepositorioFiguritas repositorioFiguritas;
   private final RepositorioSubastas repositorioSubastas;
 
@@ -36,7 +31,7 @@ public class ServicioFigurita {
       List<MetodoIntercambio> tipos, int pagina, int tamanioPagina) {
 
     FiguritasFiltro filtros = new FiguritasFiltro(null, numero, seleccion, jugador, tipos);
-    PaginaResultado<FiguritaIntercambiable> paginaRepo =
+    PaginaResultado<FiguritaIntercambiableConPerfil> paginaRepo =
         repositorioColecciones.buscarIntercambiablesConFiltros(filtros, pagina, tamanioPagina);
 
     return mapearADto(paginaRepo);
@@ -44,7 +39,7 @@ public class ServicioFigurita {
   public PaginaResultado<FiguritaIntercambiableDto> buscarPorQuery(
       String q, List<MetodoIntercambio> tipos, int pagina, int tamanioPagina) {
 
-    PaginaResultado<FiguritaIntercambiable> paginaRepo =
+    PaginaResultado<FiguritaIntercambiableConPerfil> paginaRepo =
         repositorioColecciones.buscarIntercambiablesPorQuery(q, tipos, pagina, tamanioPagina);
 
     return mapearADto(paginaRepo);
@@ -67,15 +62,18 @@ public class ServicioFigurita {
   }
 
   private PaginaResultado<FiguritaIntercambiableDto> mapearADto(
-      PaginaResultado<FiguritaIntercambiable> paginaRepo) {
+      PaginaResultado<FiguritaIntercambiableConPerfil> paginaRepo) {
 
-    Map<String, String> figuritaIdASubastaId = obtenerMapaSubastasActivas(paginaRepo.contenido());
+    List<FiguritaIntercambiable> figuritas = paginaRepo.contenido().stream()
+        .map(FiguritaIntercambiableConPerfil::figurita)
+        .toList();
+    Map<String, String> figuritaIdASubastaId = obtenerMapaSubastasActivas(figuritas);
 
     List<FiguritaIntercambiableDto> contenido = paginaRepo.contenido().stream()
-        .map(fi -> new FiguritaIntercambiableDto(
-            fi,
-            buscarPerfil(fi.getPerfilId()),
-            figuritaIdASubastaId.get(fi.getFigurita().getId())
+        .map(resultado -> new FiguritaIntercambiableDto(
+            resultado.figurita(),
+            resultado.perfil(),
+            figuritaIdASubastaId.get(resultado.figurita().getFigurita().getId())
         ))
         .toList();
 
@@ -93,11 +91,4 @@ public class ServicioFigurita {
         .toList();
   }
 
-  private Perfil buscarPerfil(String perfilId) {
-    try {
-      return repositorioPerfiles.buscarPorId(perfilId, new CamposPerfil(false));
-    } catch (NotFoundException e) {
-      return null;
-    }
-  }
 }

--- a/backend/src/test/java/app/repositories/impl/RepositorioColeccionesTest.java
+++ b/backend/src/test/java/app/repositories/impl/RepositorioColeccionesTest.java
@@ -242,7 +242,7 @@ public class RepositorioColeccionesTest extends MongoTestBase {
 
     repositorioColecciones.guardar(coleccion);
 
-    PaginaResultado<FiguritaIntercambiable> resultado =
+    var resultado =
         repositorioColecciones.buscarIntercambiablesConFiltros(
             new FiguritasFiltro(
                 null,
@@ -257,7 +257,7 @@ public class RepositorioColeccionesTest extends MongoTestBase {
 
     assertEquals(1, resultado.contenido().size());
     assertEquals("Messi",
-        resultado.contenido().get(0).getFigurita().getJugador());
+        resultado.contenido().get(0).figurita().getFigurita().getJugador());
   }
 
   @Test

--- a/backend/src/test/java/app/repositories/impl/RepositorioIntercambiablesTest.java
+++ b/backend/src/test/java/app/repositories/impl/RepositorioIntercambiablesTest.java
@@ -1,6 +1,7 @@
 package app.repositories.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import app.MongoTestBase;
@@ -51,6 +52,7 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
     Perfil perfilUno = Perfil.builder()
         .id("perfil-1").usuario(user).nombre("Lucas")
         .coleccion(coleccion)
+        .calificacionMedia(4.4)
         .mediosDeContacto(List.of(new MedioDeContacto(MedioComunicacion.TELEGRAM, "@lucas")))
         .build();
     user = new Usuario("u-2", Rol.USUARIO, "adas", "da");
@@ -81,6 +83,12 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
     var resultado = repositorioColecciones.buscarIntercambiablesConFiltros(new FiguritasFiltro(null, null, null, null, null), 1, 10);
 
     assertEquals(2, resultado.cantidadDeElementos());
+    var resultadoLucas = resultado.contenido().stream()
+        .filter(item -> "perfil-1".equals(item.figurita().getPerfilId()))
+        .findFirst()
+        .orElseThrow();
+    assertEquals("Lucas", resultadoLucas.perfil().nombre());
+    assertEquals(4.4, resultadoLucas.perfil().calificacionMedia());
   }
 
   @Test
@@ -99,7 +107,7 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
     var resultado = repositorioColecciones.buscarIntercambiablesConFiltros(new FiguritasFiltro(null, 11, null, null, null), 1, 10);
 
     assertEquals(1, resultado.cantidadDeElementos());
-    assertEquals("ARG-11", resultado.contenido().get(0).getFigurita().getId());
+    assertEquals("ARG-11", resultado.contenido().get(0).figurita().getFigurita().getId());
   }
 
   @Test
@@ -107,7 +115,10 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
     var resultado = repositorioColecciones.buscarIntercambiablesConFiltros(new FiguritasFiltro(null, null, "ARGENTINA", null, null), 1, 10);
 
     assertEquals(1, resultado.cantidadDeElementos());
-    assertEquals(Seleccion.ARGENTINA, resultado.contenido().get(0).getFigurita().getSeleccion());
+    assertEquals(
+        Seleccion.ARGENTINA,
+        resultado.contenido().get(0).figurita().getFigurita().getSeleccion()
+    );
   }
 
   @Test
@@ -122,7 +133,7 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
     var resultado = repositorioColecciones.buscarIntercambiablesConFiltros(new FiguritasFiltro(null, null, null, null, List.of(MetodoIntercambio.INTERCAMBIO)), 1, 10);
 
     assertEquals(1, resultado.cantidadDeElementos());
-    assertTrue(resultado.contenido().get(0).soporta(MetodoIntercambio.INTERCAMBIO));
+    assertTrue(resultado.contenido().get(0).figurita().soporta(MetodoIntercambio.INTERCAMBIO));
   }
 
   @Test
@@ -130,7 +141,7 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
     var resultado = repositorioColecciones.buscarIntercambiablesConFiltros(new FiguritasFiltro(null, null, null, null, List.of(MetodoIntercambio.SUBASTA)), 1, 10);
 
     assertEquals(1, resultado.cantidadDeElementos());
-    assertTrue(resultado.contenido().get(0).soporta(MetodoIntercambio.SUBASTA));
+    assertTrue(resultado.contenido().get(0).figurita().soporta(MetodoIntercambio.SUBASTA));
   }
 
   @Test
@@ -139,6 +150,60 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
 
     assertEquals(0, resultado.cantidadDeElementos());
     assertTrue(resultado.contenido().isEmpty());
+  }
+
+  @Test
+  void buscarConFiltros_perfilNuloConservaLaFigurita() {
+    Figurita figurita = Figurita.builder()
+        .id("SIN-PERFIL")
+        .numero(98)
+        .jugador("Sin perfil")
+        .seleccion(Seleccion.ARGENTINA)
+        .build();
+    repositorioFiguritas.guardar(figurita);
+    coleccion.agregarRepetida(new FiguritaIntercambiable(
+        figurita,
+        1,
+        List.of(MetodoIntercambio.INTERCAMBIO),
+        null
+    ));
+    repositorioColecciones.guardar(coleccion);
+
+    var resultado = repositorioColecciones.buscarIntercambiablesConFiltros(
+        new FiguritasFiltro("SIN-PERFIL", null, null, null, null),
+        1,
+        10
+    );
+
+    assertEquals(1, resultado.contenido().size());
+    assertNull(resultado.contenido().get(0).perfil());
+  }
+
+  @Test
+  void buscarConFiltros_perfilInexistenteConservaLaFigurita() {
+    Figurita figurita = Figurita.builder()
+        .id("PERFIL-INEXISTENTE")
+        .numero(97)
+        .jugador("Perfil inexistente")
+        .seleccion(Seleccion.ARGENTINA)
+        .build();
+    repositorioFiguritas.guardar(figurita);
+    coleccion.agregarRepetida(new FiguritaIntercambiable(
+        figurita,
+        1,
+        List.of(MetodoIntercambio.INTERCAMBIO),
+        "no-existe"
+    ));
+    repositorioColecciones.guardar(coleccion);
+
+    var resultado = repositorioColecciones.buscarIntercambiablesConFiltros(
+        new FiguritasFiltro("PERFIL-INEXISTENTE", null, null, null, null),
+        1,
+        10
+    );
+
+    assertEquals(1, resultado.contenido().size());
+    assertNull(resultado.contenido().get(0).perfil());
   }
 
   @Test
@@ -176,7 +241,10 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
     var resultado = repositorioColecciones.buscarIntercambiablesPorQuery("argentina", null, 1, 10);
 
     assertEquals(1, resultado.cantidadDeElementos());
-    assertEquals(Seleccion.ARGENTINA, resultado.contenido().get(0).getFigurita().getSeleccion());
+    assertEquals(
+        Seleccion.ARGENTINA,
+        resultado.contenido().get(0).figurita().getFigurita().getSeleccion()
+    );
   }
 
   @Test
@@ -191,7 +259,10 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
     var resultado = repositorioColecciones.buscarIntercambiablesPorQuery("10 argentina", null, 1, 10);
 
     assertEquals(1, resultado.cantidadDeElementos());
-    assertEquals(Seleccion.ARGENTINA, resultado.contenido().get(0).getFigurita().getSeleccion());
+    assertEquals(
+        Seleccion.ARGENTINA,
+        resultado.contenido().get(0).figurita().getFigurita().getSeleccion()
+    );
   }
 
   @Test
@@ -199,7 +270,7 @@ public class RepositorioIntercambiablesTest extends MongoTestBase {
     var resultado = repositorioColecciones.buscarIntercambiablesPorQuery("10", List.of(MetodoIntercambio.INTERCAMBIO), 1, 10);
 
     assertEquals(1, resultado.cantidadDeElementos());
-    assertTrue(resultado.contenido().get(0).soporta(MetodoIntercambio.INTERCAMBIO));
+    assertTrue(resultado.contenido().get(0).figurita().soporta(MetodoIntercambio.INTERCAMBIO));
   }
 
   @Test


### PR DESCRIPTION
## Descripción

Se resolvió el problema N+1 en la carga de figuritas intercambiables. Antes, el endpoint hacía 1 consulta para traer la página de figuritas y, después, 1 consulta adicional por cada perfil asociado a cada resultado. 

En una página de 12 elementos, eso terminaba en 13 consultas sólo para completar la respuesta. Si varias figuritas pertenecían al mismo perfil, ese perfil podía consultarse más de una vez, repitiendo trabajo innecesario y haciendo crecer la latencia a medida que aumentaba el tamaño de la página.

La solución mueve la resolución de perfiles del lado de MongoDB. La consulta principal primero pagina las figuritas intercambiables y después hace un `$lookup` contra la colección perfiles sobre los elementos ya paginados. Así el back deja de pedir perfiles uno por uno y pasa a recibirlos ya resueltos en la misma agregación. Además, se proyectan sólo los campos necesarios del perfil, para no cargar datos que el listado no usa.

También se separaron las proyecciones en app.repositories.projections para no mezclar el resultado de consulta con el DTO HTTP. El repositorio devuelve una proyección con la figurita y un resumen mínimo del perfil, y el servicio la transforma al formato final de respuesta.
