### PR TITLE
fix: sesión en iOS via proxy same-origin

### DIFF
--- a/RCA_SESION_IOS.md
+++ b/RCA_SESION_IOS.md
@@ -1,0 +1,65 @@
+# RCA — Sesión no persistía en iOS
+
+## Descripción del problema
+
+Los usuarios con iPhone no podían iniciar sesión en la aplicación. Tras completar el flujo de login exitosamente, cualquier navegación a una ruta protegida resultaba en el error _"No se encontró una sesión"_ y el usuario era devuelto a la pantalla de login. El problema afectaba a Safari y Chrome iOS por igual.
+
+En desktop (Chrome, Firefox) y Android el comportamiento era correcto.
+
+## Causa raíz
+
+### Mecanismo de sesión
+
+La autenticación se implementa mediante una cookie `httpOnly` llamada `token`, que contiene un JWT firmado. Al hacer login, el backend responde con un `Set-Cookie` que el browser debe almacenar y enviar en todas las requests subsiguientes.
+
+La cookie estaba configurada con `SameSite=None; Secure`, pensada para escenarios cross-site.
+
+### Por qué fallaba en iOS
+
+El frontend vive en `figunet.onrender.com` y el backend en `figunet-api.onrender.com`. Aunque visualmente parecen subdominios del mismo sitio, `onrender.com` figura en la [Public Suffix List](https://publicsuffix.org/) — el mismo registro que contiene `.com`, `.ar`, `.github.io`. Esto significa que el browser los trata como **sitios completamente distintos**, igual que si fueran `google.com` y `facebook.com`. La cookie es, por definición, **cross-site (de terceros)**.
+
+En iOS, Apple obliga a todos los browsers a usar el motor WebKit (incluso Chrome iOS es WebKit por dentro). WebKit implementa **ITP (Intelligent Tracking Prevention)**, una política de privacidad que bloquea cookies de terceros por defecto para evitar el rastreo cross-site de usuarios.
+
+Como resultado, el `Set-Cookie` que devolvía el backend al hacer login era **silenciosamente ignorado** por WebKit. Las requests subsiguientes (como `GET /yo` para verificar la sesión) viajaban sin cookie → el backend respondía 401 → el frontend mostraba _"No se encontró una sesión"_.
+
+### Por qué no fallaba en desktop
+
+Chrome y Firefox en desktop tienen políticas más permisivas con cookies `SameSite=None` siempre que vengan con `Secure`. No implementan ITP. Por eso el flujo funcionaba correctamente fuera de iOS.
+
+## Impacto
+
+- **Funcionalidad afectada:** login, sesión y toda la app (rutas protegidas inaccesibles).
+- **Usuarios afectados:** todos los usuarios con iPhone — la aplicación era inutilizable desde iOS.
+- **Plataformas no afectadas:** desktop (Chrome, Firefox, Edge) y Android.
+
+## Resolución
+
+### Proxy same-origin en Nginx
+
+Se implementó un proxy dentro del contenedor del frontend. El browser ahora solo habla con `figunet.onrender.com` — nunca ve el dominio del backend. Las requests a `/api/*` son interceptadas por Nginx y reenviadas internamente a `figunet-api.onrender.com`, quitando el prefijo `/api`.
+
+```
+Browser → figunet.onrender.com/api/login
+              ↓ Nginx (proxy interno)
+          figunet-api.onrender.com/login
+              ↓
+          Set-Cookie: token=... (asociado a figunet.onrender.com)
+```
+
+Desde la perspectiva del browser, la cookie la setea `figunet.onrender.com` → es **first-party** → WebKit la acepta y la envía en todas las requests siguientes.
+
+La URL del backend se parametriza vía la variable de entorno `BACKEND_URL`, resuelta por `envsubst` al arrancar el contenedor. Esto permite usar el mismo artefacto Docker en distintos entornos (staging, producción) cambiando solo esa variable en Render.
+
+### Cambio en la cookie
+
+Se cambió `SameSite=None` → `SameSite=Lax` en login y logout. Con el esquema same-origin este valor es el correcto: es más restrictivo (protege contra algunos vectores CSRF) y es el default moderno recomendado.
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/nginx.conf` | `location /api/` con proxy al backend y `proxy_ssl_server_name on` |
+| `frontend/Dockerfile` | `nginx.conf` copiado a `/etc/nginx/templates/` para soporte de `envsubst` |
+| `backend/.../ControladorSesion.java` | `SameSite=None` → `SameSite=Lax` en login y logout |
+| `frontend/src/services/api.js` | `baseURL` hardcodeado a `/api` |
+| `frontend/vite.config.js` | Proxy de Vite `/api` → `http://localhost:8080` para desarrollo local |

--- a/RCA_SESION_IOS.md
+++ b/RCA_SESION_IOS.md
@@ -48,7 +48,7 @@ Browser → figunet.onrender.com/api/login
 
 Desde la perspectiva del browser, la cookie la setea `figunet.onrender.com` → es **first-party** → WebKit la acepta y la envía en todas las requests siguientes.
 
-La URL del backend se parametriza vía la variable de entorno `BACKEND_URL`, resuelta por `envsubst` al arrancar el contenedor. Esto permite usar el mismo artefacto Docker en distintos entornos (staging, producción) cambiando solo esa variable en Render.
+La URL del backend se parametriza vía la variable de entorno `VITE_BACKEND_URI`, resuelta por `envsubst` al arrancar el contenedor. Esto permite usar el mismo artefacto Docker en distintos entornos (staging, producción) cambiando solo esa variable en Render.
 
 ### Cambio en la cookie
 

--- a/backend/src/main/java/app/controllers/ControladorSesion.java
+++ b/backend/src/main/java/app/controllers/ControladorSesion.java
@@ -76,7 +76,7 @@ public class ControladorSesion {
             ResponseCookie.from("token", token)
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("None")
+                .sameSite("Lax")
                 .path("/")
                 .maxAge(Duration.ofHours(12))
                 .build();
@@ -118,7 +118,7 @@ public class ControladorSesion {
             ResponseCookie.from("token", "")
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("None")
+                .sameSite("Lax")
                 .path("/")
                 .maxAge(0)
                 .build();

--- a/backend/src/test/java/app/controllers/ControladorSesionTest.java
+++ b/backend/src/test/java/app/controllers/ControladorSesionTest.java
@@ -131,7 +131,7 @@ class ControladorSesionTest {
         .andExpect(header().string("Set-Cookie",
             org.hamcrest.Matchers.containsString("HttpOnly")))
         .andExpect(header().string("Set-Cookie",
-            org.hamcrest.Matchers.containsString("SameSite=None")));
+            org.hamcrest.Matchers.containsString("SameSite=Lax")));
 
     verify(servicioSesion).login(any(LoginRequest.class));
   }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,9 +15,6 @@ COPY . .
 # Compila la app con Vite para producción
 FROM dev AS builder
 
-ARG VITE_BACKEND_URI
-ENV VITE_BACKEND_URI=$VITE_BACKEND_URI
-
 RUN npm run build
 
 # --- Etapa de runtime ---

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,7 +25,7 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:alpine AS production
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 
 EXPOSE 8080
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,6 +7,7 @@ server {
     location /api/ {
         proxy_pass ${BACKEND_URL}/;
         proxy_set_header Host $proxy_host;
+        proxy_ssl_server_name on;
     }
 
     location / {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    location /api/ {
+        proxy_pass ${BACKEND_URL}/;
+        proxy_set_header Host $proxy_host;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,7 +5,7 @@ server {
     index index.html;
 
     location /api/ {
-        proxy_pass ${BACKEND_URL}/;
+        proxy_pass ${VITE_BACKEND_URI}/;
         proxy_set_header Host $proxy_host;
         proxy_ssl_server_name on;
     }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -3,7 +3,7 @@ import {logout} from "@/services/sesionService.js";
 import {useAuth} from "@/contexts/userContext.jsx";
 
 const api = axios.create({
-    baseURL: import.meta.env.VITE_BACKEND_URI || "http://localhost:8080",
+    baseURL: import.meta.env.VITE_BACKEND_URI || "/api",
     timeout: 40000,
     headers: {
         "Content-Type": "application/json",

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -3,7 +3,7 @@ import {logout} from "@/services/sesionService.js";
 import {useAuth} from "@/contexts/userContext.jsx";
 
 const api = axios.create({
-    baseURL: import.meta.env.VITE_BACKEND_URI|| "http://localhost:8080",
+    baseURL: import.meta.env.VITE_BACKEND_URI || "http://localhost:8080",
     timeout: 40000,
     headers: {
         "Content-Type": "application/json",

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -70,23 +70,12 @@ const handleAxiosError = (error) => {
 
 //Lo que hace esto, es que cuando se detecta que el JWT dejo de ser invalido, lanza un evento para
 //setear en undefined al user.
-api.interceptors.request.use(config => {
-    console.log(`[API] ${config.method?.toUpperCase()} ${config.baseURL}${config.url}`);
-    return config;
-});
-
 api.interceptors.response.use(
-    response => {
-        console.log(`[API] ${response.status} ${response.config.url}`);
-        return response;
-    },
+    response => response,
 
     async error => {
-        const status = error.response?.status;
-        const url = error.config?.url;
-        console.error(`[API] ERROR ${status ?? "network"} ${url}`, error.message);
 
-        if (status === 401) {
+        if (error.response?.status === 401) {
 
             try {
                 await logout();

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -70,12 +70,23 @@ const handleAxiosError = (error) => {
 
 //Lo que hace esto, es que cuando se detecta que el JWT dejo de ser invalido, lanza un evento para
 //setear en undefined al user.
+api.interceptors.request.use(config => {
+    console.log(`[API] ${config.method?.toUpperCase()} ${config.baseURL}${config.url}`);
+    return config;
+});
+
 api.interceptors.response.use(
-    response => response,
+    response => {
+        console.log(`[API] ${response.status} ${response.config.url}`);
+        return response;
+    },
 
     async error => {
+        const status = error.response?.status;
+        const url = error.config?.url;
+        console.error(`[API] ERROR ${status ?? "network"} ${url}`, error.message);
 
-        if (error.response?.status === 401) {
+        if (status === 401) {
 
             try {
                 await logout();

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,5 +13,12 @@ export default defineConfig({
     watch: {
       usePolling: true,
     },
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        rewrite: (path) => path.replace(/^\/api/, ''),
+        changeOrigin: true,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Problema

Los usuarios con iPhone no podían iniciar sesión. La cookie de sesión `token` era cross-site entre `figunet.onrender.com` y `figunet-api.onrender.com` — WebKit/ITP la bloqueaba silenciosamente, resultando en 401 en todas las requests protegidas.

## Solución

Proxy Nginx en el contenedor del frontend: todas las llamadas al backend pasan por `/api/*` en el mismo origen, haciendo la cookie first-party.

## Cambios

- `nginx.conf`: proxy `/api/` → backend con `proxy_ssl_server_name on`
- `Dockerfile`: nginx.conf como template para `envsubst` (variable `BACKEND_URL` por entorno)
- `ControladorSesion.java`: `SameSite=None` → `SameSite=Lax`
- `api.js`: `baseURL` hardcodeado a `/api`
- `vite.config.js`: proxy de Vite `/api` → `http://localhost:8080` para dev local

## Variables de entorno requeridas en Render (frontend)

- `BACKEND_URL`: URL del backend (`https://figunet-api.onrender.com`)

## Justificación

Este PR re-introduce los cambios del PR #209 (`hotfix/sesion-de-usuario-nuevo`), que fue revertido en el PR #210 debido a problemas en el deploy del domingo. Los cambios de código son correctos — el problema que motivó el revert fue operativo (configuración de Render), no un bug en la solución. Se re-abre ahora apuntando a `developer` para que el fix entre por el flujo normal de integración.

## Test plan

- [ ] Login en iPhone (Safari y Chrome iOS) sin error "No se encontró una sesión"
- [ ] Navegar a rutas protegidas (`/mis-figuritas`, `/perfil`) y confirmar que cargan
- [ ] Regresión en desktop (Chrome/Firefox) y Android
- [ ] `ControladorSesionTest` pasa con `SameSite=Lax`

## IA
Se utilizó claude code para el analisis de la problematica y elaboración del RCA