### PR TITLE
Auto-login post-registro

### DIFF
--- a/backend/src/main/java/app/controllers/ControladorUsuario.java
+++ b/backend/src/main/java/app/controllers/ControladorUsuario.java
@@ -1,14 +1,21 @@
 package app.controllers;
 
+import app.dto.SesionDto;
 import app.dto.request.ContraseniaRequest;
 import app.dto.request.UsuarioRequest;
+import app.model.entities.Perfil;
 import app.model.entities.Rol;
 import app.servicios.ServicioJwt;
 import app.servicios.ServicioUsuario;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
 
 @RestController
 @RequestMapping
@@ -20,17 +27,34 @@ public class ControladorUsuario {
 
   /**
    * Registra un nuevo usuario con rol estándar. Crea la cuenta, una colección vacía
-   * y un perfil asociado.
+   * y un perfil asociado. Además emite la cookie de sesión para que el cliente
+   * quede autenticado de inmediato tras el registro.
    *
-   * @param request datos del usuario a registrar (nombre de usuario y contraseña)
-   * @return 204 No Content si el registro se realizó correctamente
+   * @param request  datos del usuario a registrar (nombre de usuario y contraseña)
+   * @param response respuesta HTTP sobre la que se setea la cookie de sesión
+   * @return 200 OK con los datos de sesión del usuario recién creado
    */
   @PostMapping("/usuarios")
-  public ResponseEntity<Void> registrarUsuario(
-      @Valid @RequestBody UsuarioRequest request
+  public ResponseEntity<SesionDto> registrarUsuario(
+      @Valid @RequestBody UsuarioRequest request,
+      HttpServletResponse response
   ) {
-    this.servicioUsuario.registrarUsuario(request);
-    return ResponseEntity.noContent().build();
+    Perfil perfil = this.servicioUsuario.registrarUsuario(request);
+
+    String token = this.servicioJwt.generarToken(perfil.getUsuario(), perfil);
+
+    ResponseCookie cookie = ResponseCookie.from("token", token)
+        .httpOnly(true)
+        .secure(true)
+        .sameSite("Lax")
+        .path("/")
+        .maxAge(Duration.ofHours(12))
+        .build();
+
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+    SesionDto sesion = this.servicioJwt.obtenerSesion(token);
+    return ResponseEntity.ok(sesion);
   }
 
   /**

--- a/backend/src/main/java/app/servicios/ServicioUsuario.java
+++ b/backend/src/main/java/app/servicios/ServicioUsuario.java
@@ -33,12 +33,13 @@ public class ServicioUsuario {
    * una colección vacía y un perfil asociado.
    *
    * @param request datos del usuario a registrar (nombre, contraseña)
+   * @return el perfil recién creado
    * @throws app.exceptions.BadRequestException si el nombre de usuario ya está en uso
    */
-  public void registrarUsuario(UsuarioRequest request) {
+  public Perfil registrarUsuario(UsuarioRequest request) {
     request.setRol(Rol.USUARIO);
 
-    this.registrar(request);
+    return this.registrar(request);
   }
 
     /**
@@ -57,6 +58,7 @@ public class ServicioUsuario {
             throw new ForbiddenException("Acceso denegado por rol invalido");
         }
     }
+
 
   /**
    * Cambia la contraseña de un usuario. Valida que la contraseña actual sea correcta
@@ -85,9 +87,10 @@ public class ServicioUsuario {
    * crea el usuario, la colección vacía y el perfil asociado.
    *
    * @param request datos del usuario a registrar
+   * @return el perfil recién creado
    * @throws app.exceptions.BadRequestException si el nombre de usuario ya está en uso
    */
-  private void registrar(UsuarioRequest request) {
+  private Perfil registrar(UsuarioRequest request) {
     PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     Usuario usuarioNuevo;
@@ -116,6 +119,8 @@ public class ServicioUsuario {
         .build();
 
     this.repositorioPerfiles.guardar(perfil);
+
+    return perfil;
   }
   /**
    * Verifica si un nombre de usuario ya está registrado en el sistema.

--- a/backend/src/test/java/app/controllers/ControladorUsuarioRegistroTest.java
+++ b/backend/src/test/java/app/controllers/ControladorUsuarioRegistroTest.java
@@ -1,0 +1,107 @@
+package app.controllers;
+
+import app.MongoTestBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Tests de integración del auto-login post-registro.
+ * Verifica que POST /usuarios setee la cookie de sesión y que los atributos
+ * sean idénticos a los del login (HttpOnly, SameSite, Path, Secure).
+ */
+@AutoConfigureMockMvc(addFilters = false)
+class ControladorUsuarioRegistroTest extends MongoTestBase {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  private static final String JSON_USUARIO_VALIDO = """
+      {
+          "nombre": "usuarioNuevo123",
+          "contrasenia": "Contrasenia1!",
+          "rol": "USUARIO"
+      }
+      """;
+
+  @Test
+  void registroExitoso_devuelve200ConCookieToken() throws Exception {
+    mockMvc.perform(post("/usuarios")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(JSON_USUARIO_VALIDO))
+        .andExpect(status().isOk())
+        .andExpect(header().exists("Set-Cookie"))
+        .andExpect(header().string("Set-Cookie", containsString("token=")))
+        .andExpect(header().string("Set-Cookie", not(containsString("token=;"))));
+  }
+
+  @Test
+  void registroExitoso_cookieTieneAtributosIgualesALogin() throws Exception {
+    mockMvc.perform(post("/usuarios")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(JSON_USUARIO_VALIDO))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Set-Cookie", containsString("HttpOnly")))
+        .andExpect(header().string("Set-Cookie", containsString("SameSite=Lax")))
+        .andExpect(header().string("Set-Cookie", containsString("Path=/")))
+        .andExpect(header().string("Set-Cookie", containsString("Secure")));
+  }
+
+  @Test
+  void registroExitoso_devuelveSesionDtoConPerfilId() throws Exception {
+    mockMvc.perform(post("/usuarios")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(JSON_USUARIO_VALIDO))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.usuario_id").isNotEmpty())
+        .andExpect(jsonPath("$.rol").value("USUARIO"))
+        .andExpect(jsonPath("$.perfil_id").isNotEmpty())
+        .andExpect(jsonPath("$.col_id").isNotEmpty());
+  }
+
+  @Test
+  void registroExitoso_cookiePermiteAccesoAEndpointAutenticado() throws Exception {
+    // Registrar y obtener la cookie de sesión
+    MvcResult resultado = mockMvc.perform(post("/usuarios")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(JSON_USUARIO_VALIDO))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String setCookieHeader = resultado.getResponse().getHeader("Set-Cookie");
+    // Extraer solo el valor "token=<jwt>" del header Set-Cookie
+    String cookieToken = setCookieHeader.split(";")[0]; // "token=<jwt>"
+    String tokenValue = cookieToken.substring("token=".length());
+
+    // Con la cookie recibida, un GET /yo debe responder 200
+    mockMvc.perform(get("/yo")
+            .cookie(new jakarta.servlet.http.Cookie("token", tokenValue)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.rol").value("USUARIO"));
+  }
+
+  @Test
+  void registroConNombreDuplicado_devuelve400SinCookie() throws Exception {
+    // Primer registro: OK
+    mockMvc.perform(post("/usuarios")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(JSON_USUARIO_VALIDO))
+        .andExpect(status().isOk());
+
+    // Segundo registro con el mismo nombre: debe fallar
+    mockMvc.perform(post("/usuarios")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(JSON_USUARIO_VALIDO))
+        .andExpect(status().isBadRequest())
+        .andExpect(header().doesNotExist("Set-Cookie"));
+  }
+}

--- a/backend/src/test/java/app/controllers/ControladorUsuarioTest.java
+++ b/backend/src/test/java/app/controllers/ControladorUsuarioTest.java
@@ -1,13 +1,15 @@
 package app.controllers;
 
+import app.dto.SesionDto;
 import app.dto.request.UsuarioRequest;
+import app.model.entities.Coleccion;
+import app.model.entities.Perfil;
 import app.model.entities.Rol;
-import app.repositories.RepositorioColecciones;
-import app.repositories.RepositorioPerfiles;
-import app.repositories.RepositorioUsuarios;
+import app.model.entities.Usuario;
 import app.servicios.ServicioJwt;
 import app.servicios.ServicioUsuario;
 import jakarta.servlet.http.Cookie;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -16,6 +18,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import app.exceptions.BadRequestException;
+import app.exceptions.ForbiddenException;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -35,13 +40,7 @@ public class ControladorUsuarioTest {
   ServicioJwt servicioJwt;
 
   @MockBean
-  RepositorioUsuarios repositorioUsuarios;
-
-  @MockBean
-  RepositorioPerfiles repositorioPerfiles;
-
-  @MockBean
-  RepositorioColecciones repositorioColecciones;
+  ServicioUsuario servicioUsuario;
 
   @Test
   void editarContraseniaDevuelve400SiBodyVacio() throws Exception {
@@ -55,19 +54,36 @@ public class ControladorUsuarioTest {
   }
 
   @Test
-  void crearUsuarioNoFalla() throws Exception {
-    String json = """
-        {
-            "nombre": "lucas",
-            "contrasenia": "Gordo123!",
-            "rol": "USUARIO"
-        }
-        """;
+  void crearUsuarioDevuelve200ConCookie() throws Exception {
+    String perfilId = new ObjectId().toString();
+    String usuarioId = new ObjectId().toString();
+    String colId = new ObjectId().toString();
+
+    Coleccion coleccion = new Coleccion();
+    coleccion.setId(colId);
+    Usuario usuario = new Usuario(usuarioId, Rol.USUARIO, "lucas", "hash");
+    Perfil perfil = Perfil.builder()
+        .usuario(usuario)
+        .nombre("lucas")
+        .coleccion(coleccion)
+        .build();
+    perfil.setId(perfilId);
+
+    when(servicioUsuario.registrarUsuario(any())).thenReturn(perfil);
+    when(servicioJwt.generarToken(any(), any())).thenReturn("jwt-generado");
+    when(servicioJwt.obtenerSesion("jwt-generado"))
+        .thenReturn(new SesionDto(usuarioId, "USUARIO", perfilId, colId));
 
     mockMvc.perform(post("/usuarios")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(json))
-        .andExpect(status().is(204));
+            .content("""
+                {
+                    "nombre": "lucas",
+                    "contrasenia": "Gordo123!",
+                    "rol": "USUARIO"
+                }
+                """))
+        .andExpect(status().isOk());
   }
   @Test
   void crearUsuarioFalla_nombreNull() throws Exception {
@@ -183,29 +199,9 @@ public class ControladorUsuarioTest {
 
   @Test
   void editarContraseniaNoFalla() throws Exception {
-
     when(servicioJwt.getPerfilId(anyString()))
         .thenReturn("perfil-id-test");
-
-    String passwordEncriptada =
-        new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder()
-            .encode("Vieja123!");
-
-    app.model.entities.Usuario usuario =
-        new app.model.entities.Usuario(
-            "user-id",
-            Rol.USUARIO,
-            "lucas",
-            passwordEncriptada
-        );
-
-    app.model.entities.Perfil perfil =
-        app.model.entities.Perfil.builder()
-            .usuario(usuario)
-            .build();
-
-    when(repositorioPerfiles.buscarPorId(anyString(), any()))
-        .thenReturn(perfil);
+    // servicioUsuario.editarContrasenia devuelve void sin lanzar excepción (mock default)
 
     mockMvc.perform(put("/usuarios/contrasenia")
             .cookie(new Cookie("token", "token-de-prueba"))
@@ -405,7 +401,8 @@ public class ControladorUsuarioTest {
 
   @Test
   void crearUsuarioFalla_nombreYaExiste() throws Exception {
-    when(repositorioUsuarios.existePorNombre("lucas")).thenReturn(true);
+    when(servicioUsuario.registrarUsuario(any()))
+        .thenThrow(new BadRequestException("El nombre de usuario ya está en uso"));
 
     mockMvc.perform(post("/usuarios")
             .contentType(MediaType.APPLICATION_JSON)
@@ -422,6 +419,8 @@ public class ControladorUsuarioTest {
   @Test
   void registrarAdministradorFalla_rolNoAdministrador() throws Exception {
     when(servicioJwt.getRol(anyString())).thenReturn("USUARIO");
+    doThrow(new ForbiddenException("Acceso denegado por rol invalido"))
+        .when(servicioUsuario).registrarAdministrador(any(), any());
 
     mockMvc.perform(post("/administradores")
             .cookie(new Cookie("token", "token-usuario"))
@@ -438,7 +437,7 @@ public class ControladorUsuarioTest {
 
   @Test
   void verificarNombreDevuelve200_siExiste() throws Exception {
-    when(repositorioUsuarios.existePorNombre("lucas")).thenReturn(true);
+    when(servicioUsuario.existeNombre("lucas")).thenReturn(true);
 
     mockMvc.perform(head("/usuarios/lucas"))
         .andExpect(status().isOk());
@@ -446,7 +445,7 @@ public class ControladorUsuarioTest {
 
   @Test
   void verificarNombreDevuelve404_siNoExiste() throws Exception {
-    when(repositorioUsuarios.existePorNombre("lucas")).thenReturn(false);
+    when(servicioUsuario.existeNombre("lucas")).thenReturn(false);
 
     mockMvc.perform(head("/usuarios/lucas"))
         .andExpect(status().isNotFound());

--- a/frontend/src/components/layouts/navbar/navbar.jsx
+++ b/frontend/src/components/layouts/navbar/navbar.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { Link, NavLink } from 'react-router-dom'
 import './navbar.css'
 import { useAuth } from '@/contexts/userContext.jsx'
@@ -18,6 +18,7 @@ const Navbar = () => {
   const [iniciales, setIniciales] = useState(undefined)
   const [notificaciones, setNotificaciones] = useState([])
   const wrapperRef = useRef(null)
+  const location = useLocation()
 
   const NAV_LINKS = [
     { to: '/explorar', label: 'Explorar' },
@@ -64,6 +65,26 @@ const Navbar = () => {
     document.addEventListener('mousedown', handleClickFuera)
     return () => document.removeEventListener('mousedown', handleClickFuera)
   }, [abierto])
+
+  // Cierra el popover con tecla Escape
+  useEffect(() => {
+    const handleEscape = async (e) => {
+      if (e.key === 'Escape' && abierto) {
+        await marcarTodasLeidas()
+        setNotificaciones((prev) => prev.map((n) => ({ ...n, leida: true })))
+        setAbierto(false)
+      }
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [abierto])
+
+  // Cierra el popover al navegar a otra ruta
+  useEffect(() => {
+    if (abierto) {
+      setAbierto(false)
+    }
+  }, [location.pathname])
 
   const toggleNotificaciones = async () => {
     if (abierto) {

--- a/frontend/src/views/public/registrar/registrar.jsx
+++ b/frontend/src/views/public/registrar/registrar.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { crearAdministrador, crearUsuario, verificarNombre } from '@/services/usuarioService.js'
+import { buscarUsuario } from '@/services/sesionService.js'
 import { useToast } from '@/contexts/toastContext.jsx'
 import { useAuth } from '@/contexts/userContext.jsx'
 import { useError } from '@/contexts/errorContext.jsx'
@@ -29,7 +30,7 @@ function Registrar() {
   })
 
   const { showToast } = useToast()
-  const { user } = useAuth()
+  const { user, asignarUsuario } = useAuth()
   const navigate = useNavigate()
 
   const validarNombre = (nombre) => {
@@ -152,11 +153,15 @@ function Registrar() {
       setOnSubmit(true)
       if (user?.rol === 'ADMINISTRADOR') {
         await crearAdministrador(usuario)
+        showToast(`Usuario creado correctamente`)
+        navigate('/')
       } else {
         await crearUsuario(usuario)
+        // Auto-login: el backend ya emitió la cookie; poblar el contexto de sesión
+        await buscarUsuario(asignarUsuario)
+        showToast(`Cuenta creada. ¡Bienvenido!`, 'success')
+        navigate('/')
       }
-      showToast(`Usuario creado correctamente`)
-      navigate('/')
     } catch (error) {
       showToast(
         handleError(error, () => {}),

--- a/frontend/src/views/public/registrar/registrar.jsx
+++ b/frontend/src/views/public/registrar/registrar.jsx
@@ -157,9 +157,12 @@ function Registrar() {
         navigate('/')
       } else {
         await crearUsuario(usuario)
-        // Auto-login: el backend ya emitió la cookie; poblar el contexto de sesión
-        await buscarUsuario(asignarUsuario)
-        showToast(`Cuenta creada. ¡Bienvenido!`, 'success')
+        if (!user) {
+          await buscarUsuario(asignarUsuario)
+          showToast(`Cuenta creada. ¡Bienvenido!`, 'success')
+        } else {
+          showToast(`Usuario creado correctamente`)
+        }
         navigate('/')
       }
     } catch (error) {


### PR DESCRIPTION
## Resumen
- `POST /usuarios` ahora emite la cookie de sesión al registrarse, evitando el paso manual de login
- El frontend puebla el contexto de sesión llamando a `GET /yo` tras el registro
- El auto-login solo corre si no hay sesión activa, para no pisar la cookie de un admin