### PR TITLE
Delete: Funcion problematica en conflicto con Lombok getEstadoActual()

### DIFF
--- a/backend/src/main/java/app/model/entities/Propuesta.java
+++ b/backend/src/main/java/app/model/entities/Propuesta.java
@@ -46,19 +46,8 @@ public class Propuesta {
         List.of(new EstadoPropuesta(LocalDateTime.now(), EstadoProceso.PENDIENTE))
     );
 
-    @Getter(AccessLevel.NONE)
     @Builder.Default
     private EstadoPropuesta estadoActual = new EstadoPropuesta(LocalDateTime.now(), EstadoProceso.PENDIENTE);
-
-    public EstadoPropuesta getEstadoActual() {
-        if (estado == null || estado.isEmpty()) {
-            EstadoPropuesta inicial = new EstadoPropuesta(LocalDateTime.now(), EstadoProceso.PENDIENTE);
-            estado = new ArrayList<>();
-            estado.add(inicial);
-            return inicial;
-        }
-        return estado.get(estado.size() - 1);
-    }
 
     /**
      * Acepta la propuesta. Valida que {@code usuario} sea el destinatario
@@ -181,7 +170,7 @@ public class Propuesta {
     }
 
     private void validarPendiente() {
-        if (getEstadoActual().getValor() != EstadoProceso.PENDIENTE) {
+        if (this.getEstadoActual().getValor() != EstadoProceso.PENDIENTE) {
             throw new BadRequestException("La propuesta ya fue respondida");
         }
     }


### PR DESCRIPTION
Elimina el getter manual getEstadoActual() de Propuesta.java que estaba en conflicto con Lombok. Antes, @Getter(AccessLevel.NONE) deshabilitaba el getter de Lombok para estadoActual, y se usaba un getter manual que:

1. Retornaba el ultimo elemento de la lista estado en vez del campo estadoActual
2. Tenia un side effect: si estado era null o vacio, mutaba el campo creando una lista nueva con un PENDIENTE

Al eliminarlo, Lombok genera un getter estandar que retorna el campo estadoActual directamente. Los metodos de negocio (aceptar, rechazar, cancelar, etc.) ya hacian setEstadoActual(actual) junto con estado.add(actual), asi que el campo siempre esta sincronizado con la lista.

**Correlacion con el bug de filtros:** El getter custom causaba que estadoActual en MongoDB se serializara con el valor del getter (ultimo de estado) en vez del campo. Si estado estaba desincronizado con estadoActual, la query Criteria.where("estadoActual.valor").is(PENDIENTE) no encontraba lo que deberia.